### PR TITLE
Fixed renew ACME API certificate bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.morihofi.acmeserver</groupId>
     <artifactId>acmeserver</artifactId>
-    <version>1.2</version>
+    <version>1.2.1</version>
     <inceptionYear>2023</inceptionYear>
 
     <properties>

--- a/src/main/resources/webstatic/index.html
+++ b/src/main/resources/webstatic/index.html
@@ -32,14 +32,14 @@
           //Parse JSON
           var responseJSON = JSON.parse(this.responseText);
 
-          document.getElementById("version").innerHTML = responseJSON.version;
+          document.getElementById("version").innerHTML = responseJSON.metadataInfo.version;
           document.getElementById("buildtime").innerHTML =
-            responseJSON.buildtime;
+            responseJSON.metadataInfo.buildtime;
           document.getElementById("gitcommit").innerHTML =
-            responseJSON.gitcommit;
+            responseJSON.metadataInfo.gitcommit;
           document.getElementById("javaversion").innerHTML =
-            responseJSON.javaversion;
-          document.getElementById("os").innerHTML = responseJSON.os;
+            responseJSON.metadataInfo.javaversion;
+          document.getElementById("os").innerHTML = responseJSON.metadataInfo.os;
 
           const container = document.getElementById("provisioner-container");
           const ul = document.createElement("ul");


### PR DESCRIPTION
Fixed renew ACME API certificate bug:
Certificate was not renewed, even when it has expired, due to incorrect if statement