### PR TITLE
Update Dockerfile and build configs to JDK 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   test-java:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0
     steps:
       - checkout
       - run:

--- a/.gitea/workflows/java-build.yml
+++ b/.gitea/workflows/java-build.yml
@@ -14,7 +14,7 @@ jobs:
         uses: https://github.com/actions/checkout@v3
 
       - name: Maven Clean Compile
-        uses: docker://maven:3.9-eclipse-temurin-17-alpine
+        uses: docker://maven:3.9-eclipse-temurin-21-alpine
         with:
           entrypoint: /bin/sh
           args: -c "mvn clean compile -B"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ COPY --from=frontendbuilder /app/frontend/.output/public /app/target/classes/web
 # Compile and create package
 RUN mvn package
 
-# Third stage: Execution with Java 17 Temurin
-FROM eclipse-temurin:17-jdk AS runner
+# Third stage: Execution with Java 21 Temurin
+FROM eclipse-temurin:21-jdk AS runner
 WORKDIR /app
 # Copying the built artifact from the first stage
 COPY --from=builder /app/target/acmeserver.jar app.jar

--- a/README.MD
+++ b/README.MD
@@ -9,7 +9,7 @@
 
 This is an implementation of an Automatic Certificate Management Environment (ACME) Server, fully written in Java
 
-- Java 17 and up
+- Java 21 and up
 - Any JDBC (and Hibernate compatible) database. Currently, H2, MariaDB and PostgreSQL drivers are in classpath
 - Proxy support for HTTP Challenge
 
@@ -128,4 +128,4 @@ on coding standards and practices. This ensures that the code keeps readable and
 - [Acme4j](https://github.com/shred/acme4j) (It's client implementation helped me to generate the expected DNS Challenge
   value on the server side)
 - [CabinetMaker](https://github.com/grahamrb/CabinetMaker) for generating CAB file using pure Java, it has been
-  refactored for Java 17+
+  refactored for Java 21+

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ If you don't use a released JAR, you need to build it yourself.
 
 You'll need the following prerequisites to be able to build ACME Server
 
-- Java 17
+- Java 21
 - Maven 3.9
 
 ### Initiating the build


### PR DESCRIPTION
## Summary
- use `eclipse-temurin:21-jdk` in Dockerfile runtime stage
- update CI configs to Java 21
- document Java 21 requirement in README files

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68482301555083229edd283d485add59