### PR TITLE
Fix ACME error status codes

### DIFF
--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEAlreadyRevokedException.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEAlreadyRevokedException.java
@@ -41,7 +41,6 @@ public class ACMEAlreadyRevokedException extends ACMEException {
 
     @Override
     public int getHttpStatusCode() {
-        // TODO: Check if this is correct
         return 400;
     }
 

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEBadCsrException.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEBadCsrException.java
@@ -41,7 +41,6 @@ public class ACMEBadCsrException extends ACMEException {
 
     @Override
     public int getHttpStatusCode() {
-        // TODO: Check if this is the correct code
         return 400;
     }
 

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEBadRevocationReasonException.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEBadRevocationReasonException.java
@@ -41,7 +41,6 @@ public class ACMEBadRevocationReasonException extends ACMEException {
 
     @Override
     public int getHttpStatusCode() {
-        // TODO: Check if this is correct
         return 400;
     }
 

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEConnectionErrorException.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEConnectionErrorException.java
@@ -41,8 +41,7 @@ public class ACMEConnectionErrorException extends ACMEException {
 
     @Override
     public int getHttpStatusCode() {
-        // TODO: Check if this is correct
-        return 403;
+        return 400;
     }
 
     @Override

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEMalformedException.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEMalformedException.java
@@ -41,7 +41,6 @@ public class ACMEMalformedException extends ACMEException {
 
     @Override
     public int getHttpStatusCode() {
-        // TODO: Check if correct
         return 400;
     }
 

--- a/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEExceptionStatusCodeTest.java
+++ b/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEExceptionStatusCodeTest.java
@@ -23,11 +23,20 @@ class ACMEExceptionStatusCodeTest {
 
     static Stream<Arguments> exceptionProvider() {
         return Stream.of(
+                Arguments.of(new ACMEAccountNotFoundException("msg"), 404),
                 Arguments.of(new ACMEAlreadyRevokedException("msg"), 400),
-                Arguments.of(new ACMEConnectionErrorException("msg"), 400),
                 Arguments.of(new ACMEBadCsrException("msg"), 400),
+                Arguments.of(new ACMEBadNonceException("msg"), 400),
+                Arguments.of(new ACMEBadPublicKeyException("msg"), 400),
                 Arguments.of(new ACMEBadRevocationReasonException("msg"), 400),
-                Arguments.of(new ACMEMalformedException("msg"), 400)
+                Arguments.of(new ACMEBadSignatureAlgorithmException("msg"), 400),
+                Arguments.of(new ACMEConnectionErrorException("msg"), 400),
+                Arguments.of(new ACMEInvalidContactException("msg"), 403),
+                Arguments.of(new ACMEMalformedException("msg"), 400),
+                Arguments.of(new ACMERateLimitedException("msg"), 429),
+                Arguments.of(new ACMERejectedIdentifierException("msg"), 400),
+                Arguments.of(new ACMEUnauthorizedException("msg"), 403),
+                Arguments.of(new ACMEServerInternalException("msg"), 500)
         );
     }
 }

--- a/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEExceptionStatusCodeTest.java
+++ b/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEExceptionStatusCodeTest.java
@@ -1,0 +1,33 @@
+package de.morihofi.acmeserver.types.exception.exceptions;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.DisplayName;
+import de.morihofi.acmeserver.types.exception.ACMEException;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for verifying HTTP status codes of ACME exceptions.
+ */
+class ACMEExceptionStatusCodeTest {
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("exceptionProvider")
+    @DisplayName("getHttpStatusCode returns expected status")
+    void testHttpStatus(ACMEException exception, int expectedStatus) {
+        assertEquals(expectedStatus, exception.getHttpStatusCode());
+    }
+
+    static Stream<Arguments> exceptionProvider() {
+        return Stream.of(
+                Arguments.of(new ACMEAlreadyRevokedException("msg"), 400),
+                Arguments.of(new ACMEConnectionErrorException("msg"), 400),
+                Arguments.of(new ACMEBadCsrException("msg"), 400),
+                Arguments.of(new ACMEBadRevocationReasonException("msg"), 400),
+                Arguments.of(new ACMEMalformedException("msg"), 400)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- remove TODO comments and confirm status codes
- set connection error to use HTTP 400
- add unit tests for ACME exception status codes

## Testing
- `mvn -q test -pl acmeserver-types` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848231f167083229391ad33c01ea851