### PR TITLE
Add Replay-Nonce header to ACME errors

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
@@ -42,6 +42,7 @@ import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.CertificateRe
 import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
 import de.morihofi.acmeserver.core.tools.network.logging.HTTPAccessLogger;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.database.entities.HttpNonces;
 import io.javalin.Javalin;
 import io.javalin.http.HandlerType;
 import io.javalin.http.staticfiles.Location;
@@ -135,6 +136,7 @@ public class WebServer {
         app.exception(ACMEException.class, (exception, ctx) -> {
             ctx.status(exception.getHttpStatusCode());
             ctx.header("Content-Type", "application/problem+json");
+            ctx.header("Replay-Nonce", HttpNonces.createNonce(serverInstance));
             ctx.json(exception.getErrorResponse());
             log.error("ACME Exception thrown {} : {} ({})", exception.getClass().getSimpleName(), exception.getErrorResponse().getDetail(),
                     exception.getErrorResponse().getType());


### PR DESCRIPTION
## Summary
- update `WebServer` so the global `ACMEException` handler adds a fresh `Replay-Nonce` header

## Testing
- `sh mvnw -q -pl acmeserver-core test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68485b6eab888322ab56e21b46cb1cd4