### PR TITLE
Use order expiration in authz response

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpoint.java
@@ -167,11 +167,21 @@ public class AuthzOwnershipEndpoint extends AbstractAcmeEndpoint {
 
         AuthzResponse response = new AuthzResponse();
         response.setStatus(identifier.getChallengeStatus().getRfcName());
-        response.setExpires(DateTools.formatDateForACME(new Date())); // FIXME
+        response.setExpires(DateTools.formatDateForACME(getAuthorizationExpiration(identifier)));
         response.setIdentifier(idObj);
         response.setChallenges(challengeResponses);
 
         ctx.json(response);
+    }
+
+    /**
+     * Returns the expiration timestamp for the provided authorization identifier.
+     *
+     * @param identifier The ACME order identifier.
+     * @return The expiration {@link Date} of the authorization.
+     */
+    Date getAuthorizationExpiration(@NotNull AcmeOrderIdentifier identifier) {
+        return identifier.getOrder().getExpires();
     }
 
     /**

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpointTest.java
@@ -1,0 +1,40 @@
+package de.morihofi.acmeserver.core.api.acme.api.endpoints.authz;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifier;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import org.hibernate.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthzOwnershipEndpointTest {
+
+    static class DummyServerInstance implements IServerInstance {
+        @Override public String getServerURL() { return ""; }
+        @Override public Session getDatabaseSession() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.ICryptoStoreManager getCryptoStoreManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.config.Config getAppConfig() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.INonceManager getNonceManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+        @Override public de.morihofi.acmeserver.types.runtime.BuildMetadata getBuildMetadata() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+    }
+
+    @Test
+    @DisplayName("Authorization expiration comes from associated order")
+    void testAuthorizationExpiration() {
+        AuthzOwnershipEndpoint endpoint = new AuthzOwnershipEndpoint(new DummyServerInstance());
+        AcmeOrder order = new AcmeOrder();
+        Timestamp expires = Timestamp.from(Instant.now().plusSeconds(3600));
+        order.setExpires(expires);
+        AcmeOrderIdentifier identifier = new AcmeOrderIdentifier("dns", "example.com");
+        identifier.setOrder(order);
+
+        assertEquals(expires, endpoint.getAuthorizationExpiration(identifier));
+    }
+}


### PR DESCRIPTION
## Summary
- link authorization expiry to the parent order
- expose helper for retrieving the expiration date
- test that authorization expiration comes from its order

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68485b73a1548322a329d20bca3c1954