### PR TITLE
Implement userActionRequired exception

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/NewAccountEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/NewAccountEndpoint.java
@@ -29,11 +29,12 @@ import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.types.database.entities.HttpNonces;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEInvalidContactException;
-import de.morihofi.acmeserver.types.exception.exceptions.ACMEMalformedException;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMEUserActionRequiredException;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEServerInternalException;
 import de.morihofi.acmeserver.cryptography.pem.PemUtil;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.regex.EmailValidator;
+import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
 import io.javalin.http.Context;
 
 import lombok.extern.slf4j.Slf4j;
@@ -81,7 +82,12 @@ public class NewAccountEndpoint extends AbstractAcmeEndpoint {
 
         // Check terms of service agreement
         if (!payload.isTermsOfServiceAgreed()) {
-            throw new ACMEMalformedException("Terms of Service not accepted. Unable to create account");
+            String tosUrl = "about:blank";
+            if (provisioner.getMeta().getTos() != null) {
+                tosUrl = provisioner.getMeta().getTos().trim();
+            }
+            ctx.header("Link", HttpHeaderUtil.buildLinkHeaderValue(tosUrl, "terms-of-service"));
+            throw new ACMEUserActionRequiredException("User must agree to terms of service");
         }
 
         // Validate email addresses

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEUserActionRequiredException.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEUserActionRequiredException.java
@@ -1,0 +1,38 @@
+package de.morihofi.acmeserver.types.exception.exceptions;
+
+import de.morihofi.acmeserver.types.exception.ACMEException;
+import de.morihofi.acmeserver.types.exception.objects.ErrorResponse;
+
+/**
+ * Exception thrown when user interaction is required before continuing with the ACME workflow.
+ */
+public class ACMEUserActionRequiredException extends ACMEException {
+
+    /**
+     * Message sent back to the client
+     */
+    private final String message;
+
+    /**
+     * Constructs an instance of ACMEUserActionRequiredException with the specified error message.
+     *
+     * @param message The error message that describes the exception.
+     */
+    public ACMEUserActionRequiredException(String message) {
+        super(message);
+        this.message = message;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return 403;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return ErrorResponse.builder()
+                .type("urn:ietf:params:acme:error:userActionRequired")
+                .detail(message)
+                .build();
+    }
+}

--- a/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEExceptionStatusCodeTest.java
+++ b/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEExceptionStatusCodeTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.DisplayName;
 import de.morihofi.acmeserver.types.exception.ACMEException;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMEUserActionRequiredException;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
@@ -36,7 +37,21 @@ class ACMEExceptionStatusCodeTest {
                 Arguments.of(new ACMERateLimitedException("msg"), 429),
                 Arguments.of(new ACMERejectedIdentifierException("msg"), 400),
                 Arguments.of(new ACMEUnauthorizedException("msg"), 403),
-                Arguments.of(new ACMEServerInternalException("msg"), 500)
+                Arguments.of(new ACMEServerInternalException("msg"), 500),
+                Arguments.of(new ACMEUserActionRequiredException("msg"), 403)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("errorTypeProvider")
+    @DisplayName("getErrorResponse returns expected type")
+    void testErrorType(ACMEException exception, String expectedType) {
+        assertEquals(expectedType, exception.getErrorResponse().getType());
+    }
+
+    static Stream<Arguments> errorTypeProvider() {
+        return Stream.of(
+                Arguments.of(new ACMEUserActionRequiredException("msg"), "urn:ietf:params:acme:error:userActionRequired")
         );
     }
 }


### PR DESCRIPTION
## Summary
- add `ACMEUserActionRequiredException`
- enforce TOS in `NewAccountEndpoint` using the new exception and `Link` header
- test the new exception type and status code

## Testing
- `mvn test` *(fails: PluginResolutionException, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68485b874f1c8322af6f667f68a21ea9