### PR TITLE
Use order expiration timestamp

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpoint.java
@@ -83,7 +83,6 @@ public class OrderInfoEndpoint extends AbstractAcmeEndpoint {
         boolean allVerified = true;
         List<Identifier> identifierList = new ArrayList<>();
         List<String> authorizationsList = new ArrayList<>();
-        Date orderExpires = new Date();
 
         for (AcmeOrderIdentifier identifier : identifiers) {
             if (identifier.getChallengeStatus() != AcmeStatus.VALID) {
@@ -95,7 +94,7 @@ public class OrderInfoEndpoint extends AbstractAcmeEndpoint {
         }
 
         ACMEOrderResponse response = new ACMEOrderResponse();
-        response.setExpires(DateTools.formatDateForACME(orderExpires));
+        response.setExpires(DateTools.formatDateForACME(getOrderExpiration(order)));
 
         if (order.getCertificatePem() != null) {
             response.setStatus(AcmeStatus.VALID.getRfcName());
@@ -116,5 +115,15 @@ public class OrderInfoEndpoint extends AbstractAcmeEndpoint {
         response.setAuthorizations(authorizationsList);
 
         ctx.json(response);
+    }
+
+    /**
+     * Returns the expiration timestamp for the provided order.
+     *
+     * @param order The ACME order.
+     * @return The expiration {@link Date} of the order.
+     */
+    Date getOrderExpiration(@NotNull AcmeOrder order) {
+        return order.getExpires();
     }
 }

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpointTest.java
@@ -1,0 +1,37 @@
+package de.morihofi.acmeserver.core.api.acme.api.endpoints.order;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import org.hibernate.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrderInfoEndpointTest {
+
+    static class DummyServerInstance implements IServerInstance {
+        @Override public String getServerURL() { return ""; }
+        @Override public Session getDatabaseSession() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.ICryptoStoreManager getCryptoStoreManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.config.Config getAppConfig() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.INonceManager getNonceManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+        @Override public de.morihofi.acmeserver.types.runtime.BuildMetadata getBuildMetadata() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+    }
+
+    @Test
+    @DisplayName("Order expiration comes from stored order")
+    void testOrderExpiration() {
+        OrderInfoEndpoint endpoint = new OrderInfoEndpoint(new DummyServerInstance());
+        AcmeOrder order = new AcmeOrder();
+        Timestamp expires = Timestamp.from(Instant.now().plusSeconds(3600));
+        order.setExpires(expires);
+
+        assertEquals(expires, endpoint.getOrderExpiration(order));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `OrderInfoEndpoint` returns the stored expiration date
- unit test verifying expiration retrieval

## Testing
- `mvn -q -pl acmeserver-core test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68485e728304832293f6b9e828f3cd0f