### PR TITLE
Add authorization validation before storing CSR

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/FinalizeOrderEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/FinalizeOrderEndpoint.java
@@ -30,6 +30,7 @@ import de.morihofi.acmeserver.types.database.entities.*;
 import de.morihofi.acmeserver.types.database.enums.AcmeOrderState;
 import de.morihofi.acmeserver.types.database.enums.AcmeStatus;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEBadCsrException;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMEUnauthorizedException;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.base64.Base64Tools;
 import de.morihofi.acmeserver.utils.datetime.DateTools;
@@ -57,6 +58,14 @@ public class FinalizeOrderEndpoint extends AbstractAcmeEndpoint {
         super(serverInstance);
     }
 
+    void verifyAuthorizationsComplete(@NotNull List<AcmeOrderIdentifier> identifiers) throws ACMEUnauthorizedException {
+        boolean allValid = identifiers.stream()
+                .allMatch(id -> id.getChallengeStatus() == AcmeStatus.VALID);
+        if (!allValid) {
+            throw new ACMEUnauthorizedException("One or more identifiers are not validated yet");
+        }
+    }
+
     @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     @Override
     public void handleRequest(@NotNull Context ctx, @NotNull AcmeProvisioner provisioner, @NotNull Gson gson, @NotNull ACMERequestBody acmeRequestBody) throws Exception {
@@ -76,6 +85,9 @@ public class FinalizeOrderEndpoint extends AbstractAcmeEndpoint {
 
         // Get our ACME identifiers
         List<AcmeOrderIdentifier> identifiers = AcmeOrder.getACMEOrder(orderId, getServerInstance()).getOrderIdentifiers();
+
+        // Ensure all authorizations are completed before processing the CSR
+        verifyAuthorizationsComplete(identifiers);
 
         // We just use the verification, that throws exceptions, here not the resulting identifiers
         CsrDataUtil.getCsrIdentifiersAndVerifyWithIdentifiers(csr, identifiers);

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/FinalizeOrderEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/FinalizeOrderEndpointTest.java
@@ -1,0 +1,60 @@
+package de.morihofi.acmeserver.core.api.acme.api.endpoints.order;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifier;
+import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifierChallenge;
+import de.morihofi.acmeserver.types.database.enums.AcmeStatus;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMEUnauthorizedException;
+import org.hibernate.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FinalizeOrderEndpointTest {
+
+    static class DummyServerInstance implements IServerInstance {
+        @Override public String getServerURL() { return ""; }
+        @Override public Session getDatabaseSession() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.ICryptoStoreManager getCryptoStoreManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.config.Config getAppConfig() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.INonceManager getNonceManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+        @Override public de.morihofi.acmeserver.types.runtime.BuildMetadata getBuildMetadata() { return null; }
+        @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+    }
+
+    private static AcmeOrderIdentifierChallenge challengeWithStatus(AcmeOrderIdentifier id, AcmeStatus status) {
+        AcmeOrderIdentifierChallenge c = new AcmeOrderIdentifierChallenge();
+        c.setStatus(status);
+        c.setIdentifier(id);
+        return c;
+    }
+
+    @Test
+    @DisplayName("verifyAuthorizationsComplete throws when any identifier invalid")
+    void testVerifyAuthorizationsIncomplete() {
+        FinalizeOrderEndpoint endpoint = new FinalizeOrderEndpoint(new DummyServerInstance());
+        AcmeOrderIdentifier id1 = new AcmeOrderIdentifier("dns", "example.com");
+        AcmeOrderIdentifier id2 = new AcmeOrderIdentifier("dns", "example.org");
+        id1.setChallenges(List.of(challengeWithStatus(id1, AcmeStatus.VALID)));
+        id2.setChallenges(List.of(challengeWithStatus(id2, AcmeStatus.PENDING)));
+
+        assertThrows(ACMEUnauthorizedException.class,
+                () -> endpoint.verifyAuthorizationsComplete(List.of(id1, id2)));
+    }
+
+    @Test
+    @DisplayName("verifyAuthorizationsComplete passes when all identifiers valid")
+    void testVerifyAuthorizationsComplete() {
+        FinalizeOrderEndpoint endpoint = new FinalizeOrderEndpoint(new DummyServerInstance());
+        AcmeOrderIdentifier id1 = new AcmeOrderIdentifier("dns", "example.com");
+        AcmeOrderIdentifier id2 = new AcmeOrderIdentifier("dns", "example.org");
+        id1.setChallenges(List.of(challengeWithStatus(id1, AcmeStatus.VALID)));
+        id2.setChallenges(List.of(challengeWithStatus(id2, AcmeStatus.VALID)));
+
+        assertDoesNotThrow(() -> endpoint.verifyAuthorizationsComplete(List.of(id1, id2)));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure all identifiers are VALID before processing finalize order requests
- raise `ACMEUnauthorizedException` when identifiers are incomplete
- add tests for authorization validation logic

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848636ae0548322bd3b6f560df86416