### PR TITLE
Rename verified property to validated

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/ChallengeCallbackEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/ChallengeCallbackEndpoint.java
@@ -116,7 +116,7 @@ public class ChallengeCallbackEndpoint extends AbstractAcmeEndpoint {
         response.setType(challengeType);
         if (identifierChallenge.getStatus() == AcmeStatus.VALID) {
             response.setStatus(AcmeStatus.VALID.getRfcName());
-            response.setVerified(DateTools.formatDateForACME(identifierChallenge.getVerifiedTime()));
+            response.setValidated(DateTools.formatDateForACME(identifierChallenge.getVerifiedTime()));
         } else {
             response.setStatus(AcmeStatus.PENDING.getRfcName());
         }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/objects/ACMEChallengeResponse.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/objects/ACMEChallengeResponse.java
@@ -16,10 +16,13 @@
 
 package de.morihofi.acmeserver.core.api.acme.api.endpoints.challenge.objects;
 
+import lombok.Data;
+
 /**
  * Represents the response for an ACME challenge. This class encapsulates the details required
  * for the ACME challenge operations such as status, validation date, challenge URL, token, and type.
  */
+@Data
 public class ACMEChallengeResponse {
 
     /**
@@ -46,94 +49,4 @@ public class ACMEChallengeResponse {
      * Type of the challenge.
      */
     private String type;
-
-    /**
-     * Retrieves the status of the ACME challenge.
-     *
-     * @return The status of the challenge.
-     */
-    public String getStatus() {
-        return status;
-    }
-
-    /**
-     * Sets the status of the ACME challenge.
-     *
-     * @param status The status to set.
-     */
-    public void setStatus(String status) {
-        this.status = status;
-    }
-
-    /**
-     * Retrieves the validated date of the ACME challenge.
-     *
-     * @return The validated date as a string.
-     */
-    public String getValidated() {
-        return validated;
-    }
-
-    /**
-     * Sets the validated date of the ACME challenge.
-     *
-     * @param validated The validated date to set.
-     */
-    public void setValidated(String validated) {
-        this.validated = validated;
-    }
-
-    /**
-     * Retrieves the URL for challenge approval.
-     *
-     * @return The URL for challenge approval.
-     */
-    public String getUrl() {
-        return url;
-    }
-
-    /**
-     * Sets the URL for challenge approval.
-     *
-     * @param url The URL to set.
-     */
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    /**
-     * Retrieves the token to place for the ACME challenge.
-     *
-     * @return The token for the challenge.
-     */
-    public String getToken() {
-        return token;
-    }
-
-    /**
-     * Sets the token to place for the ACME challenge.
-     *
-     * @param token The token to set.
-     */
-    public void setToken(String token) {
-        this.token = token;
-    }
-
-    /**
-     * Retrieves the type of the ACME challenge.
-     *
-     * @return The type of the challenge.
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * Sets the type of the ACME challenge.
-     *
-     * @param type The type to set.
-     */
-    public void setType(String type) {
-        this.type = type;
-    }
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/objects/ACMEChallengeResponse.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/objects/ACMEChallengeResponse.java
@@ -18,7 +18,7 @@ package de.morihofi.acmeserver.core.api.acme.api.endpoints.challenge.objects;
 
 /**
  * Represents the response for an ACME challenge. This class encapsulates the details required
- * for the ACME challenge operations such as status, verification date, challenge URL, token, and type.
+ * for the ACME challenge operations such as status, validation date, challenge URL, token, and type.
  */
 public class ACMEChallengeResponse {
 
@@ -28,9 +28,9 @@ public class ACMEChallengeResponse {
     private String status;
 
     /**
-     * Verified date, formatted as a string.
+     * Validated date, formatted as a string.
      */
-    private String verified;
+    private String validated;
 
     /**
      * URL for challenge approval.
@@ -66,21 +66,21 @@ public class ACMEChallengeResponse {
     }
 
     /**
-     * Retrieves the verified date of the ACME challenge.
+     * Retrieves the validated date of the ACME challenge.
      *
-     * @return The verified date as a string.
+     * @return The validated date as a string.
      */
-    public String getVerified() {
-        return verified;
+    public String getValidated() {
+        return validated;
     }
 
     /**
-     * Sets the verified date of the ACME challenge.
+     * Sets the validated date of the ACME challenge.
      *
-     * @param verified The verified date to set.
+     * @param validated The validated date to set.
      */
-    public void setVerified(String verified) {
-        this.verified = verified;
+    public void setValidated(String validated) {
+        this.validated = validated;
     }
 
     /**


### PR DESCRIPTION
## Summary
- rename `verified` property in `ACMEChallengeResponse` to `validated`
- update `ChallengeCallbackEndpoint` to set the new `validated` field

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848637883cc8322b916d8a57269345b