### PR TITLE
Add missing resource exception for ACME authz

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpoint.java
@@ -24,7 +24,7 @@ import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifier;
 import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifierChallenge;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.types.database.entities.HttpNonces;
-import de.morihofi.acmeserver.types.exception.exceptions.ACMEMalformedException;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMEResourceNotFoundException;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEServerInternalException;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.base64.Base64Tools;
@@ -92,7 +92,7 @@ public class AuthzOwnershipEndpoint extends AbstractAcmeEndpoint {
         // Not found handling
         if (identifier == null) {
             log.error("Throwing API error: For the requested authorization id {} was no identifier found", authorizationId);
-            throw new ACMEMalformedException("For the requested authorization id was no identifier found");
+            throw new ACMEResourceNotFoundException("For the requested authorization id was no identifier found");
         }
 
         // Check signature and nonce

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpointTest.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -55,44 +56,5 @@ class AuthzOwnershipEndpointTest {
         identifier.setOrder(order);
 
         assertEquals(expires, endpoint.getAuthorizationExpiration(identifier));
-    }
-
-    static class DummyContext implements Context {
-        private final String authorizationId;
-        DummyContext(String authorizationId) { this.authorizationId = authorizationId; }
-        @Override public String pathParam(String s) { return authorizationId; }
-        @Override public Context header(String s, String s1) { return this; }
-        @Override public Context status(int i) { return this; }
-        // Unused methods
-        @Override public String body() { return null; }
-        @Override public HttpServletRequest req() { return null; }
-        @Override public HttpServletResponse res() { return null; }
-        @Override public HandlerType handlerType() { return null; }
-        @Override public String matchedPath() { return null; }
-        @Override public String endpointHandlerPath() { return null; }
-        @Override public <T> T appData(Key<T> key) { return null; }
-        @Override public JsonMapper jsonMapper() { return null; }
-        @Override public <T> T with(Class<? extends ContextPlugin<?, T>> plugin) { return null; }
-        @Override public boolean strictContentTypes() { return false; }
-        @Override public Map<String, String> pathParamMap() { return Collections.emptyMap(); }
-        @Override public ServletOutputStream outputStream() { return null; }
-        @Override public Context minSizeForCompression(int i) { return this; }
-        @Override public Context result(InputStream inputStream) { return this; }
-        @Override public InputStream resultInputStream() { return null; }
-        @Override public void future(Supplier<? extends CompletableFuture<?>> supplier) { }
-        @Override public void redirect(String s, HttpStatus httpStatus) { }
-        @Override public void writeJsonStream(Stream<?> stream) { }
-        @Override public Context skipRemainingHandlers() { return this; }
-        @Override public Set<io.javalin.security.RouteRole> routeRoles() { return Collections.emptySet(); }
-    }
-
-    @Test
-    @DisplayName("Nonexistent authorization results in 404")
-    void testNonexistentAuthorization() {
-        AuthzOwnershipEndpoint endpoint = new AuthzOwnershipEndpoint(new DummyServerInstance());
-        Context ctx = new DummyContext("authz-unknown");
-        ACMEResourceNotFoundException ex = assertThrows(ACMEResourceNotFoundException.class,
-                () -> endpoint.handleRequest(ctx, new AcmeProvisioner(), new Gson(), new ACMERequestBody()));
-        assertEquals(404, ex.getHttpStatusCode());
     }
 }

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpointTest.java
@@ -1,11 +1,30 @@
 package de.morihofi.acmeserver.core.api.acme.api.endpoints.authz;
 
+import com.google.gson.Gson;
+import de.morihofi.acmeserver.core.api.acme.api.objects.ACMERequestBody;
 import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
 import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifier;
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMEResourceNotFoundException;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
+import io.javalin.config.Key;
+import io.javalin.http.Context;
+import io.javalin.http.HandlerType;
+import io.javalin.http.HttpStatus;
+import io.javalin.json.JsonMapper;
+import io.javalin.plugin.ContextPlugin;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.hibernate.Session;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -36,5 +55,44 @@ class AuthzOwnershipEndpointTest {
         identifier.setOrder(order);
 
         assertEquals(expires, endpoint.getAuthorizationExpiration(identifier));
+    }
+
+    static class DummyContext implements Context {
+        private final String authorizationId;
+        DummyContext(String authorizationId) { this.authorizationId = authorizationId; }
+        @Override public String pathParam(String s) { return authorizationId; }
+        @Override public Context header(String s, String s1) { return this; }
+        @Override public Context status(int i) { return this; }
+        // Unused methods
+        @Override public String body() { return null; }
+        @Override public HttpServletRequest req() { return null; }
+        @Override public HttpServletResponse res() { return null; }
+        @Override public HandlerType handlerType() { return null; }
+        @Override public String matchedPath() { return null; }
+        @Override public String endpointHandlerPath() { return null; }
+        @Override public <T> T appData(Key<T> key) { return null; }
+        @Override public JsonMapper jsonMapper() { return null; }
+        @Override public <T> T with(Class<? extends ContextPlugin<?, T>> plugin) { return null; }
+        @Override public boolean strictContentTypes() { return false; }
+        @Override public Map<String, String> pathParamMap() { return Collections.emptyMap(); }
+        @Override public ServletOutputStream outputStream() { return null; }
+        @Override public Context minSizeForCompression(int i) { return this; }
+        @Override public Context result(InputStream inputStream) { return this; }
+        @Override public InputStream resultInputStream() { return null; }
+        @Override public void future(Supplier<? extends CompletableFuture<?>> supplier) { }
+        @Override public void redirect(String s, HttpStatus httpStatus) { }
+        @Override public void writeJsonStream(Stream<?> stream) { }
+        @Override public Context skipRemainingHandlers() { return this; }
+        @Override public Set<io.javalin.security.RouteRole> routeRoles() { return Collections.emptySet(); }
+    }
+
+    @Test
+    @DisplayName("Nonexistent authorization results in 404")
+    void testNonexistentAuthorization() {
+        AuthzOwnershipEndpoint endpoint = new AuthzOwnershipEndpoint(new DummyServerInstance());
+        Context ctx = new DummyContext("authz-unknown");
+        ACMEResourceNotFoundException ex = assertThrows(ACMEResourceNotFoundException.class,
+                () -> endpoint.handleRequest(ctx, new AcmeProvisioner(), new Gson(), new ACMERequestBody()));
+        assertEquals(404, ex.getHttpStatusCode());
     }
 }

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEResourceNotFoundException.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEResourceNotFoundException.java
@@ -1,0 +1,38 @@
+package de.morihofi.acmeserver.types.exception.exceptions;
+
+import de.morihofi.acmeserver.types.exception.ACMEException;
+import de.morihofi.acmeserver.types.exception.objects.ErrorResponse;
+
+/**
+ * Exception thrown when an expected ACME resource is not found.
+ */
+public class ACMEResourceNotFoundException extends ACMEException {
+
+    /**
+     * Message sent back to the client
+     */
+    private final String message;
+
+    /**
+     * Constructs an instance of ACMEResourceNotFoundException with the specified error message.
+     *
+     * @param message The error message that describes the exception.
+     */
+    public ACMEResourceNotFoundException(String message) {
+        super(message);
+        this.message = message;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return 404;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return ErrorResponse.builder()
+                .type("urn:ietf:params:acme:error:notFound")
+                .detail(message)
+                .build();
+    }
+}

--- a/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEExceptionStatusCodeTest.java
+++ b/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/exception/exceptions/ACMEExceptionStatusCodeTest.java
@@ -25,6 +25,7 @@ class ACMEExceptionStatusCodeTest {
     static Stream<Arguments> exceptionProvider() {
         return Stream.of(
                 Arguments.of(new ACMEAccountNotFoundException("msg"), 404),
+                Arguments.of(new ACMEResourceNotFoundException("msg"), 404),
                 Arguments.of(new ACMEAlreadyRevokedException("msg"), 400),
                 Arguments.of(new ACMEBadCsrException("msg"), 400),
                 Arguments.of(new ACMEBadNonceException("msg"), 400),
@@ -51,7 +52,8 @@ class ACMEExceptionStatusCodeTest {
 
     static Stream<Arguments> errorTypeProvider() {
         return Stream.of(
-                Arguments.of(new ACMEUserActionRequiredException("msg"), "urn:ietf:params:acme:error:userActionRequired")
+                Arguments.of(new ACMEUserActionRequiredException("msg"), "urn:ietf:params:acme:error:userActionRequired"),
+                Arguments.of(new ACMEResourceNotFoundException("msg"), "urn:ietf:params:acme:error:notFound")
         );
     }
 }


### PR DESCRIPTION
## Summary
- add `ACMEResourceNotFoundException`
- throw the new exception in `AuthzOwnershipEndpoint` when identifier is missing
- test HTTP status codes including the new exception
- verify requesting missing authorization throws `ACMEResourceNotFoundException`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684863666f5083229ee82ce1d23acc56