### PR TITLE
Fix challenge state transitions

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/ChallengeCallbackEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/ChallengeCallbackEndpoint.java
@@ -78,6 +78,9 @@ public class ChallengeCallbackEndpoint extends AbstractAcmeEndpoint {
             throw new ACMEMalformedException("DNS-01 method is only valid for non wildcard domains");
         }
 
+        // move challenge into processing state before performing validation
+        AcmeOrderIdentifierChallenge.markChallenge(AcmeStatus.PROCESSING, challengeId, getServerInstance());
+
         ChallengeResult result = switch (challengeType) {
             case "http-01" -> HTTPChallenge.check(
                     identifierChallenge.getAuthorizationToken(),

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/database/entities/AcmeOrderIdentifierChallenge.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/database/entities/AcmeOrderIdentifierChallenge.java
@@ -116,42 +116,34 @@ public class AcmeOrderIdentifierChallenge implements Serializable {
 
     /**
      * Returns {@code true} iff the requested state change is permitted by the ACME
-     *  authorization-status state machine (RFC 8555 §7.1.6).
+     *  challenge-status state machine (RFC 8555 §7.1.5).
      *
      * <pre>
-     *              pending ──┬─────────► valid ──┬────────► revoked   (server)
-     *                        │                   │
-     *                        │                   ├────────► deactivated (client or server)
-     *                        │                   │
-     *                        │                   └────────► expired    (clock)
-     *                        │
-     *                        └─────────► invalid   (challenge failure / error)
+     *              pending ──► processing ──┬─────► valid
+     *                        │             └─────► invalid
+     *                        └─────────────► invalid
      * </pre>
      *
-     * Once an authorization is in {@code invalid}, {@code revoked}, {@code
-     * deactivated}, or {@code expired}, it is a terminal state and can no longer
-     * transition.
+     * Once a challenge is in {@code valid} or {@code invalid}, it is a terminal state and can no longer transition.
      */
     static boolean isChallengeTransitionAllowed(@NonNull AcmeStatus currentState,
                                                 @NonNull AcmeStatus newState) {
 
         return switch (currentState) {
             /* -------------------------------- pending --------------------------- */
-            case PENDING -> newState == AcmeStatus.VALID
-                    || newState == AcmeStatus.INVALID
-                    || newState == AcmeStatus.DEACTIVATED;
+            case PENDING -> newState == AcmeStatus.PROCESSING 
+                    || newState == AcmeStatus.INVALID;
 
-            /* -------------------------------- valid ----------------------------- */
-            case VALID -> newState == AcmeStatus.DEACTIVATED
-                    || newState == AcmeStatus.REVOKED
-                    || newState == AcmeStatus.EXPIRED;
+            /* -------------------------------- processing --------------------- */
+            case PROCESSING -> newState == AcmeStatus.PROCESSING 
+                    || newState == AcmeStatus.VALID 
+                    || newState == AcmeStatus.INVALID;
 
-            /* ------------- terminal states: nothing may change them ------------- */
-            case INVALID, DEACTIVATED, REVOKED, EXPIRED -> false;
+            case VALID, INVALID -> false;
 
             /* ------------- unknown enum constant (defensive fallback) ----------- */
             default -> {
-                log.warn("Unknown authorization state '{}'; refusing transition to '{}'",
+                log.warn("Unknown challenge state '{}'; refusing transition to '{}'",
                         currentState, newState);
                 yield false;
             }

--- a/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/database/entities/ACMEOrderIdentifierChallengeStatusTransitionTest.java
+++ b/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/database/entities/ACMEOrderIdentifierChallengeStatusTransitionTest.java
@@ -12,18 +12,17 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Unit tests for {@link AcmeOrderIdentifierChallenge#isChallengeTransitionAllowed(AcmeStatus, AcmeStatus)}.
  */
-@DisplayName("ACME authorization-state transitions")
+@DisplayName("ACME challenge-state transitions")
 class ACMEOrderIdentifierChallengeStatusTransitionTest {
 
     /* ---------- transitions that the spec ALLOWS ---------- */
     @ParameterizedTest(name = "{index}: {0} ➜ {1} must be allowed")
     @CsvSource({
-            "PENDING, VALID",
+            "PENDING, PROCESSING",
             "PENDING, INVALID",
-            "PENDING, DEACTIVATED",
-            "VALID,   DEACTIVATED",
-            "VALID,   REVOKED",
-            "VALID,   EXPIRED"
+            "PROCESSING, PROCESSING",
+            "PROCESSING, VALID",
+            "PROCESSING, INVALID"
     })
     void allowedTransitions(AcmeStatus from, AcmeStatus to) {
         assertTrue(AcmeOrderIdentifierChallenge.isChallengeTransitionAllowed(from, to));
@@ -32,19 +31,23 @@ class ACMEOrderIdentifierChallengeStatusTransitionTest {
     /* ---------- transitions that the spec FORBIDS ---------- */
     @ParameterizedTest(name = "{index}: {0} ➜ {1} must be rejected")
     @CsvSource({
-            // anything other than VALID / INVALID / DEACTIVATED out of PENDING
+            // disallowed transitions from PENDING
+            "PENDING, VALID",
+            "PENDING, DEACTIVATED",
             "PENDING, REVOKED",
             "PENDING, EXPIRED",
 
+            // disallowed transitions from PROCESSING
+            "PROCESSING, DEACTIVATED",
+            "PROCESSING, REVOKED",
+            "PROCESSING, EXPIRED",
+            "PROCESSING, PENDING",
+
             // terminal states cannot change again
-            "INVALID, PENDING",
+            "VALID, PROCESSING",
+            "VALID, PENDING",
             "INVALID, VALID",
-            "DEACTIVATED, VALID",
-            "DEACTIVATED, PENDING",
-            "REVOKED,   VALID",
-            "REVOKED,   PENDING",
-            "EXPIRED,   VALID",
-            "EXPIRED,   PENDING"
+            "INVALID, PROCESSING"
     })
     void forbiddenTransitions(AcmeStatus from, AcmeStatus to) {
         assertFalse(AcmeOrderIdentifierChallenge.isChallengeTransitionAllowed(from, to));


### PR DESCRIPTION
## Summary
- correct ACME challenge state machine and log message
- enforce processing state during challenge validation
- update tests for new state transitions

## Testing
- `mvn -pl acmeserver-types test -DtrimStackTrace=false`
- `mvn -pl acmeserver-types,acmeserver-core test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684925b6a2988322aa69a4abe89310ee