### PR TITLE
Add CI coverage check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,11 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum "/tmp/CIRCLECI_CACHE_KEY" }}
       - run:
-          command: mvn verify
+          command: mvn -B verify
       - store_test_results:
           path: target/surefire-reports
+      - store_artifacts:
+          path: target/site/jacoco
       - save_cache:
           key: cache-{{ checksum "/tmp/CIRCLECI_CACHE_KEY" }}
           paths:

--- a/.gitea/workflows/java-build.yml
+++ b/.gitea/workflows/java-build.yml
@@ -8,13 +8,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: https://github.com/actions/checkout@v3
-
-      - name: Maven Clean Compile
+      - name: Maven Verify with Coverage
         uses: docker://maven:3.9-eclipse-temurin-21-alpine
         with:
           entrypoint: /bin/sh
-          args: -c "mvn clean compile -B"
+          args: -c "mvn -B verify"
+      - name: Upload coverage
+        uses: https://github.com/actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco

--- a/acmeserver-parent/pom.xml
+++ b/acmeserver-parent/pom.xml
@@ -77,6 +77,47 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- check test coverage with Jacoco in parent POM
- run `mvn -B verify` in pipelines and store coverage artifacts

## Testing
- `mvn -Djacoco.skip=true -DskipITs -e verify`

------
https://chatgpt.com/codex/tasks/task_e_6849b952c30483229d2c67de1a18d00d