### PR TITLE
Fix order identifier check

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpoint.java
@@ -30,6 +30,8 @@ import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.types.database.entities.HttpNonces;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.datetime.DateTools;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMEResourceNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import io.javalin.http.Context;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,6 +44,7 @@ import java.util.List;
  * Endpoint for retrieving information about an ACME order.
  * This class handles the request to fetch detailed information about a specific ACME order by its ID.
  */
+@Slf4j
 public class OrderInfoEndpoint extends AbstractAcmeEndpoint {
 
 
@@ -72,9 +75,7 @@ public class OrderInfoEndpoint extends AbstractAcmeEndpoint {
 
         AcmeOrder order = AcmeOrder.getAcmeOrder(orderId, getServerInstance());
         List<AcmeOrderIdentifier> identifiers = order.getOrderIdentifiers();
-        if (identifiers.isEmpty()) {
-            throw new IllegalArgumentException("Identifiers empty, FIXME");
-        }
+        verifyIdentifiersPresent(orderId, identifiers);
 
         // Check signature and nonce
         SignatureCheck.checkSignature(ctx, identifiers.getFirst().getOrder().getAccount(), gson, getServerInstance());
@@ -125,5 +126,19 @@ public class OrderInfoEndpoint extends AbstractAcmeEndpoint {
      */
     Date getOrderExpiration(@NotNull AcmeOrder order) {
         return order.getExpires();
+    }
+
+    /**
+     * Ensures that an order contains at least one identifier.
+     *
+     * @param orderId    The ID of the order being validated.
+     * @param identifiers The list of identifiers associated with the order.
+     * @throws ACMEResourceNotFoundException if no identifiers are present.
+     */
+    void verifyIdentifiersPresent(@NotNull String orderId, @NotNull List<AcmeOrderIdentifier> identifiers) {
+        if (identifiers.isEmpty()) {
+            log.error("Throwing API error: For the requested order {} was no identifier found", orderId);
+            throw new ACMEResourceNotFoundException("For the requested order id was no identifier found");
+        }
     }
 }

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpointTest.java
@@ -2,12 +2,15 @@ package de.morihofi.acmeserver.core.api.acme.api.endpoints.order;
 
 import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifier;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMEResourceNotFoundException;
 import org.hibernate.Session;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,5 +36,21 @@ class OrderInfoEndpointTest {
         order.setExpires(expires);
 
         assertEquals(expires, endpoint.getOrderExpiration(order));
+    }
+
+    @Test
+    @DisplayName("verifyIdentifiersPresent throws when list empty")
+    void testVerifyIdentifiersPresentThrows() {
+        OrderInfoEndpoint endpoint = new OrderInfoEndpoint(new DummyServerInstance());
+        assertThrows(ACMEResourceNotFoundException.class,
+                () -> endpoint.verifyIdentifiersPresent("test", List.of()));
+    }
+
+    @Test
+    @DisplayName("verifyIdentifiersPresent passes with identifiers")
+    void testVerifyIdentifiersPresentOk() {
+        OrderInfoEndpoint endpoint = new OrderInfoEndpoint(new DummyServerInstance());
+        AcmeOrderIdentifier id = new AcmeOrderIdentifier("dns", "example.com");
+        assertDoesNotThrow(() -> endpoint.verifyIdentifiersPresent("test", List.of(id)));
     }
 }


### PR DESCRIPTION
## Summary
- ensure OrderInfoEndpoint returns RFC-compliant error when no identifiers exist
- log missing order identifiers and throw `ACMEResourceNotFoundException`
- expose `verifyIdentifiersPresent` and test it
- cover valid and invalid order IDs in `OrderInfoEndpointTest`

## Testing
- `mvn test -DtrimStackTrace=false`

------
https://chatgpt.com/codex/tasks/task_e_6849e2b2a40883228d04b236f8828bb0