### PR TITLE
Add CAA record validation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -66,9 +66,9 @@ Server.
   writing this) are included, if specified version not available it will try to fetch these from the Mozilla server.
   Note: Version before 5.1 might be a bit buggy)
 - Support for ACME account key rollover
+- CAA-Lookup (see [RFC 6844](https://datatracker.ietf.org/doc/html/rfc6844))
 
 ## Features in the future
-- CAA-Lookup (see [RFC 6844](https://datatracker.ietf.org/doc/html/rfc6844))
 
 ## ✅ Testing status
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuer.java
@@ -27,6 +27,8 @@ import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.base64.Base64Tools;
 import de.morihofi.acmeserver.cryptography.pem.PemUtil;
 import de.morihofi.acmeserver.core.tools.certificate.generator.ServerCertificateGenerator;
+import de.morihofi.acmeserver.utils.network.dns.CAAValidator;
+import de.morihofi.acmeserver.types.exception.exceptions.ACMECaaException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -87,6 +89,21 @@ public class CertificateIssuer {
 
         Set<Identifier> csrIdentifiers = CsrDataUtil.getCsrIdentifiersAndVerifyWithIdentifiers(csr, order.getOrderIdentifiers());
         AcmeProvisioner provisioner = order.getAccount().getAcmeProvisioner();
+
+        // Perform CAA checks for each DNS identifier
+        String caDomain = serverInstance.getAppConfig().getServer().getDnsName();
+        for (Identifier id : csrIdentifiers) {
+            if (id.getTypeAsEnumConstant() == Identifier.IDENTIFIER_TYPE.DNS) {
+                boolean allowed = CAAValidator.isIssuanceAllowed(
+                        id.getValue(),
+                        caDomain,
+                        serverInstance.getAppConfig().getNetwork().getDnsConfig(),
+                        serverInstance.getNetworkClient());
+                if (!allowed) {
+                    throw new ACMECaaException("CAA forbids issuance for domain " + id.getValue());
+                }
+            }
+        }
 
         /*
             We just use the DNS Domain Names (Subject Alternative Name) and the public key of the CSR. We're not using

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMECaaException.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/exception/exceptions/ACMECaaException.java
@@ -1,0 +1,35 @@
+package de.morihofi.acmeserver.types.exception.exceptions;
+
+import de.morihofi.acmeserver.types.exception.ACMEException;
+import de.morihofi.acmeserver.types.exception.objects.ErrorResponse;
+
+/**
+ * Exception thrown when certificate issuance is blocked by a CAA record.
+ */
+public class ACMECaaException extends ACMEException {
+
+    private final String message;
+
+    /**
+     * Constructs the exception with a message detailing the CAA violation.
+     *
+     * @param message error description
+     */
+    public ACMECaaException(String message) {
+        super(message);
+        this.message = message;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return 403;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return ErrorResponse.builder()
+                .type("urn:ietf:params:acme:error:caa")
+                .detail(message)
+                .build();
+    }
+}

--- a/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/network/dns/CAAValidator.java
+++ b/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/network/dns/CAAValidator.java
@@ -1,0 +1,71 @@
+package de.morihofi.acmeserver.utils.network.dns;
+
+import de.morihofi.acmeserver.types.config.network.DNSConfig;
+import de.morihofi.acmeserver.types.intf.network.INetworkClient;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.xbill.DNS.CAARecord;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.Type;
+
+import java.util.List;
+
+/**
+ * Utility class for performing CAA lookups in accordance with RFC 6844.
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CAAValidator {
+
+    /**
+     * Determines if issuance is permitted for the given domain based on CAA records.
+     *
+     * @param domain       Domain to check.
+     * @param caDomain     Domain name of this CA used in CAA issue tags.
+     * @param dnsConfig    DNS configuration of the server.
+     * @param networkClient Network client for performing lookups.
+     * @return {@code true} if issuance is allowed, otherwise {@code false}.
+     */
+    public static boolean isIssuanceAllowed(@NonNull String domain, @NonNull String caDomain,
+                                            @NonNull DNSConfig dnsConfig, @NonNull INetworkClient networkClient) {
+        List<Record> records;
+        if (dnsConfig.getDohEnabled()) {
+            records = DNSLookup.performDoHLookup(domain + ".", Type.CAA, networkClient.getDoHClient());
+        } else {
+            records = DNSLookup.performDnsServerLookup(domain + ".", Type.CAA, dnsConfig.getDnsServers());
+        }
+        return evaluateCaaRecords(records, caDomain);
+    }
+
+    /**
+     * Evaluates the provided CAA records.
+     *
+     * @param records   List of DNS records.
+     * @param caDomain  Domain name of this CA.
+     * @return {@code true} if issuance is allowed.
+     */
+    public static boolean evaluateCaaRecords(List<Record> records, @NonNull String caDomain) {
+        if (records == null || records.isEmpty()) {
+            return true; // No CAA records found -> issuance allowed
+        }
+
+        boolean allowed = false;
+        for (Record r : records) {
+            if (r instanceof CAARecord caa) {
+                String tag = caa.getTag();
+                String value = caa.getValue();
+                if (("issue".equalsIgnoreCase(tag) || "issuewild".equalsIgnoreCase(tag)) &&
+                        value.equalsIgnoreCase(caDomain)) {
+                    allowed = true;
+                } else if ("issue".equalsIgnoreCase(tag) || "issuewild".equalsIgnoreCase(tag)) {
+                    // Explicitly forbids this CA
+                    log.info("Domain {} contains CAA record for different CA {}", caa.getName(), value);
+                    return false;
+                }
+            }
+        }
+        return allowed;
+    }
+}

--- a/acmeserver-utils/src/test/java/de/morihofi/acmeserver/utils/network/dns/CAAValidatorTest.java
+++ b/acmeserver-utils/src/test/java/de/morihofi/acmeserver/utils/network/dns/CAAValidatorTest.java
@@ -1,0 +1,30 @@
+package de.morihofi.acmeserver.utils.network.dns;
+
+import org.junit.jupiter.api.Test;
+import org.xbill.DNS.CAARecord;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.Record;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CAAValidatorTest {
+
+    @Test
+    void testNoRecordsAllowed() throws Exception {
+        assertTrue(CAAValidator.evaluateCaaRecords(List.of(), "ca.example"));
+    }
+
+    @Test
+    void testRecordAllows() throws Exception {
+        Record rec = new CAARecord(Name.fromString("example.com."), 1, 3600, 0, "issue", "ca.example");
+        assertTrue(CAAValidator.evaluateCaaRecords(List.of(rec), "ca.example"));
+    }
+
+    @Test
+    void testRecordForbids() throws Exception {
+        Record rec = new CAARecord(Name.fromString("example.com."), 1, 3600, 0, "issue", "other.ca");
+        assertFalse(CAAValidator.evaluateCaaRecords(List.of(rec), "ca.example"));
+    }
+}

--- a/docs/03_CAA_Configuration.md
+++ b/docs/03_CAA_Configuration.md
@@ -1,0 +1,40 @@
+# 3. CAA Records
+
+Certificate Authority Authorization (CAA) records allow a domain owner to specify which Certificate Authorities (CAs) are permitted to issue certificates for their domain.
+ACME Server will query these records according to [RFC&nbsp;6844](https://datatracker.ietf.org/doc/html/rfc6844) before issuing a certificate.
+
+## How it works
+
+1. When a certificate request is received, ACME Server performs DNS lookups for CAA records of the requested domain.
+2. If no CAA records are found, issuance is allowed.
+3. If one or more `issue` or `issuewild` records are present, at least one entry must match the CA domain of this server. Other CAs listed will cause issuance to be denied.
+4. `iodef` records are ignored by the server but may be used by domain owners to receive violation reports.
+
+## Configuring CAA records
+
+Create `CAA` records in your authoritative DNS zone. A basic example using BIND style notation looks like:
+
+```
+example.com.  0  CAA  0 issue "acme.example.com"
+example.com.  0  CAA  0 iodef "mailto:caa-reports@example.com"
+```
+
+* `issue` &ndash; Authorizes the CA with the specified domain (`acme.example.com`) to issue certificates.
+* `issuewild` &ndash; Same as `issue` but specifically for wildcard certificates (`*.example.com`). Omit or set to an empty string to forbid wildcard issuance.
+* `iodef` &ndash; Optional address (mailto or https) where policy violations are reported.
+
+The CA domain must match the `server.dnsName` configured in `settings.json` so that ACME Server recognizes itself in the CAA record.
+
+### Wildcard certificates
+
+If you plan to issue wildcard certificates, add an `issuewild` tag pointing to the server domain:
+
+```
+example.com. 0 CAA 0 issuewild "acme.example.com"
+```
+
+Domains without matching `issue`/`issuewild` records will cause requests to fail with a `caa` ACME error.
+
+### Testing your configuration
+
+After publishing the records, use tools such as `dig` or [DNS lookup websites](https://dns.google/) to verify that the CAA records resolve correctly. Remember that DNS changes may take time to propagate.


### PR DESCRIPTION
## Summary
- validate CAA records before issuing certificates
- handle CAA errors via new ACMECaaException
- expose CAA lookup helper utility
- document new feature in README
- cover CAA evaluation logic with unit tests
- explain configuring CAA records in the docs manual

## Testing
- `mvn -DskipTests=false test`

------
https://chatgpt.com/codex/tasks/task_e_6849ef1bcd54832298c6703cb7867739