### PR TITLE
Add challenge unit tests

### DIFF
--- a/acmeserver-core/pom.xml
+++ b/acmeserver-core/pom.xml
@@ -149,6 +149,12 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/challenges/DNSChallengeTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/challenges/DNSChallengeTest.java
@@ -1,0 +1,110 @@
+package de.morihofi.acmeserver.core.api.acme.challenges;
+
+import de.morihofi.acmeserver.cryptography.acme.AcmeTokenCryptography;
+import de.morihofi.acmeserver.cryptography.pem.PemUtil;
+import de.morihofi.acmeserver.core.tools.crypto.Hashing;
+import de.morihofi.acmeserver.types.config.Config;
+import de.morihofi.acmeserver.types.config.network.DNSConfig;
+import de.morihofi.acmeserver.types.config.network.NetworkConfig;
+import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
+import de.morihofi.acmeserver.types.intf.INonceManager;
+import de.morihofi.acmeserver.types.intf.network.INetworkClient;
+import de.morihofi.acmeserver.types.intf.network.dns.IDoHClient;
+import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import de.morihofi.acmeserver.utils.base64.Base64Tools;
+import de.morihofi.acmeserver.utils.network.dns.DNSLookup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.TXTRecord;
+import org.xbill.DNS.Type;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DNSChallengeTest {
+
+    static class DummyServerInstance implements IServerInstance {
+        private final INetworkClient net = new INetworkClient() {
+            @Override public okhttp3.OkHttpClient getOkHttpClient() { return new okhttp3.OkHttpClient(); }
+            @Override public IDoHClient getDoHClient() { return null; }
+            @Override public List<String> getDnsServer() { return Collections.emptyList(); }
+            @Override public java.net.Proxy getProxy() { return java.net.Proxy.NO_PROXY; }
+        };
+        private final Config cfg;
+        DummyServerInstance() {
+            cfg = new Config();
+            NetworkConfig nc = new NetworkConfig();
+            nc.setDnsConfig(new DNSConfig());
+            cfg.setNetwork(nc);
+        }
+        @Override public String getServerURL() { return ""; }
+        @Override public org.hibernate.Session getDatabaseSession() { return null; }
+        @Override public ICryptoStoreManager getCryptoStoreManager() { return null; }
+        @Override public Config getAppConfig() { return cfg; }
+        @Override public INonceManager getNonceManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+        @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
+        @Override public INetworkClient getNetworkClient() { return net; }
+    }
+
+    @Test
+    @DisplayName("getDigest computes expected value")
+    void testGetDigest() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(512);
+        KeyPair kp = kpg.generateKeyPair();
+        String token = "tok";
+        String expected = Base64Tools.base64UrlEncode(Hashing.sha256hash(AcmeTokenCryptography.keyAuthorizationFor(token, kp.getPublic())));
+        assertEquals(expected, DNSChallenge.getDigest(token, kp.getPublic()));
+    }
+
+    @Test
+    @DisplayName("check returns success when TXT record matches")
+    void testCheckSuccess() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(512);
+        KeyPair kp = kpg.generateKeyPair();
+        String token = "tok";
+        AcmeAccount acc = new AcmeAccount();
+        acc.setPublicKeyPEM(PemUtil.convertToPem(kp.getPublic()));
+
+        String digest = DNSChallenge.getDigest(token, kp.getPublic());
+        Record rec = new TXTRecord(Name.fromString("_acme-challenge.example.com."), 1, 60, digest);
+
+        try (MockedStatic<DNSLookup> mock = Mockito.mockStatic(DNSLookup.class)) {
+            mock.when(() -> DNSLookup.performDnsServerLookup(Mockito.anyString(), Mockito.eq(Type.TXT), Mockito.anyList())).thenReturn(List.of(rec));
+            ChallengeResult result = DNSChallenge.check(token, "example.com", acc, new DummyServerInstance());
+            assertTrue(result.successful());
+        }
+    }
+
+    @Test
+    @DisplayName("check fails when no record matches")
+    void testCheckFail() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(512);
+        KeyPair kp = kpg.generateKeyPair();
+        String token = "tok";
+        AcmeAccount acc = new AcmeAccount();
+        acc.setPublicKeyPEM(PemUtil.convertToPem(kp.getPublic()));
+
+        Record rec = new TXTRecord(Name.fromString("_acme-challenge.example.com."), 1, 60, "wrong");
+
+        try (MockedStatic<DNSLookup> mock = Mockito.mockStatic(DNSLookup.class)) {
+            mock.when(() -> DNSLookup.performDnsServerLookup(Mockito.anyString(), Mockito.eq(Type.TXT), Mockito.anyList())).thenReturn(List.of(rec));
+            ChallengeResult result = DNSChallenge.check(token, "example.com", acc, new DummyServerInstance());
+            assertFalse(result.successful());
+        }
+    }
+}
+

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/challenges/HTTPChallengeTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/challenges/HTTPChallengeTest.java
@@ -1,0 +1,115 @@
+package de.morihofi.acmeserver.core.api.acme.challenges;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import de.morihofi.acmeserver.cryptography.pem.PemUtil;
+import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
+import de.morihofi.acmeserver.types.intf.INonceManager;
+import de.morihofi.acmeserver.types.intf.network.INetworkClient;
+import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HTTPChallengeTest {
+
+    static class DummyNetworkClient implements INetworkClient {
+        private final OkHttpClient client = new OkHttpClient();
+        @Override public OkHttpClient getOkHttpClient() { return client; }
+        @Override public de.morihofi.acmeserver.types.intf.network.dns.IDoHClient getDoHClient() { return null; }
+        @Override public java.util.List<String> getDnsServer() { return Collections.emptyList(); }
+        @Override public Proxy getProxy() { return Proxy.NO_PROXY; }
+    }
+
+    static class DummyServerInstance implements IServerInstance {
+        private final INetworkClient net = new DummyNetworkClient();
+        private final BuildMetadata meta = BuildMetadata.builder().buildVersion("test").gitCommit("abc").build();
+        @Override public String getServerURL() { return ""; }
+        @Override public org.hibernate.Session getDatabaseSession() { return null; }
+        @Override public ICryptoStoreManager getCryptoStoreManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.config.Config getAppConfig() { return null; }
+        @Override public INonceManager getNonceManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+        @Override public BuildMetadata getBuildMetadata() { return meta; }
+        @Override public INetworkClient getNetworkClient() { return net; }
+    }
+
+    private HttpServer server;
+    private int port;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        port = server.getAddress().getPort();
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private void setHandler(String path, String body) {
+        server.createContext(path, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                exchange.sendResponseHeaders(200, body.getBytes().length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body.getBytes());
+                }
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("check returns success for valid token")
+    void testCheckValid() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(512);
+        KeyPair kp = kpg.generateKeyPair();
+        String token = "token123";
+
+        AcmeAccount account = new AcmeAccount();
+        account.setPublicKeyPEM(PemUtil.convertToPem(kp.getPublic()));
+
+        String expected = de.morihofi.acmeserver.cryptography.acme.AcmeTokenCryptography.keyAuthorizationFor(token, kp.getPublic());
+        setHandler("/.well-known/acme-challenge/" + token, expected);
+
+        ChallengeResult result = HTTPChallenge.check(token, "localhost:" + port, account, new DummyServerInstance());
+        assertTrue(result.successful());
+    }
+
+    @Test
+    @DisplayName("check fails on invalid token")
+    void testCheckInvalid() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(512);
+        KeyPair kp = kpg.generateKeyPair();
+        String token = "token123";
+
+        AcmeAccount account = new AcmeAccount();
+        account.setPublicKeyPEM(PemUtil.convertToPem(kp.getPublic()));
+
+        setHandler("/.well-known/acme-challenge/" + token, "wrong");
+
+        ChallengeResult result = HTTPChallenge.check(token, "localhost:" + port, account, new DummyServerInstance());
+        assertFalse(result.successful());
+        assertNotNull(result.errorReason());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Mockito test dependency
- test HTTP challenge using local HTTP server
- test DNS challenge with static mock

## Testing
- `mvn -q -DskipITs=true test`

------
https://chatgpt.com/codex/tasks/task_e_684a7bd2bd248322abcbed49f0c80c16