### PR TITLE
Refactor OCSP logic into cryptography module

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspEndpointGet.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspEndpointGet.java
@@ -18,6 +18,7 @@ package de.morihofi.acmeserver.core.certificate.revokeDistribution;
 
 
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.cryptography.ocsp.OcspHelper;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.javalin.http.Context;

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspEndpointPost.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspEndpointPost.java
@@ -18,6 +18,7 @@ package de.morihofi.acmeserver.core.certificate.revokeDistribution;
 
 
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.cryptography.ocsp.OcspHelper;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.javalin.http.Context;

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspEndpointGetTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspEndpointGetTest.java
@@ -4,8 +4,15 @@ import com.google.common.jimfs.Jimfs;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
 import de.morihofi.acmeserver.cryptography.keys.KeyPairGenerator;
 import de.morihofi.acmeserver.cryptography.keystore.CryptoStoreManager;
-import de.morihofi.acmeserver.cryptography.revoke.CrlGenerator;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisionerDomainNameRestriction;
+import de.morihofi.acmeserver.types.database.entities.ProvisionerMeta;
+import de.morihofi.acmeserver.types.database.entities.RootCa;
+import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import de.morihofi.acmeserver.types.database.entities.RsaCertificateAlgorithm;
+import de.morihofi.acmeserver.types.config.Config;
+import de.morihofi.acmeserver.types.config.DatabaseConfig;
 import de.morihofi.acmeserver.types.database.entities.CertificateConfig;
 import de.morihofi.acmeserver.types.database.entities.CertificateExpiration;
 import de.morihofi.acmeserver.types.database.entities.CertificateMetadata;
@@ -13,6 +20,8 @@ import de.morihofi.acmeserver.types.cryptography.keystore.PKCS12KeyStoreConfig;
 import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import de.morihofi.acmeserver.core.database.HibernateUtil;
+import org.hibernate.Transaction;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.ocsp.CertificateID;
 import org.bouncycastle.cert.ocsp.OCSPReq;
@@ -36,9 +45,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.Security;
-import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
-import java.time.LocalTime;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -96,12 +103,14 @@ class OcspEndpointGetTest {
     private OcspEndpointGet endpoint;
     private AcmeProvisioner prov;
     private IServerInstance si;
+    private CryptoStoreManager csm;
+    private HibernateUtil hu;
 
     @BeforeEach
     void init() throws Exception {
         FileSystem fs = Jimfs.newFileSystem();
         Path ksPath = fs.getPath("store.p12");
-        CryptoStoreManager csm = new CryptoStoreManager(new PKCS12KeyStoreConfig(ksPath, "".toCharArray()));
+        csm = new CryptoStoreManager(new PKCS12KeyStoreConfig(ksPath, "".toCharArray()));
 
         KeyPair rootKey = KeyPairGenerator.generateRSAKeyPair(1024, BouncyCastleProvider.PROVIDER_NAME);
         X509Certificate rootCert = X509Generator.generate(X509Generator.Request.builder()
@@ -122,34 +131,58 @@ class OcspEndpointGetTest {
         csm.getKeyStore().setKeyEntry(csm.getKeyStoreAliasForProvisionerIntermediate("test"),
                 interKey.getPrivate(), "".toCharArray(), new java.security.cert.Certificate[]{interCert});
 
+        Config cfg = new Config();
+        DatabaseConfig db = new DatabaseConfig();
+        db.setJdbcUrl("jdbc:h2:mem:" + java.util.UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        db.setUser("sa");
+        db.setPassword("");
+        cfg.setDatabase(db);
+
+        hu = new HibernateUtil(cfg, true);
+
+        RootCa root = new RootCa();
+        root.setCertificateConfig(cfg("root"));
+        root.setInternalUuid("root");
+
         prov = new AcmeProvisioner();
         prov.setName("test");
+        prov.setRootCa(root);
+        prov.setMeta(new ProvisionerMeta("", ""));
+        prov.setCertificateConfig(cfg("inter"));
+        prov.setIssuedCertificateExpiration(new CertificateExpiration(0,0,1));
+        prov.setWildcardAllowed(false);
+        prov.setIpAllowed(true);
+        AcmeProvisionerDomainNameRestriction r = new AcmeProvisionerDomainNameRestriction();
+        r.setEnabled(false);
+        r.setMustEndWith(Collections.emptyList());
+        prov.setAcmeProvisionerDomainNameRestriction(r);
+
+        try (Session s = hu.getSessionFactory().openSession()) {
+            Transaction tx = s.beginTransaction();
+            s.persist(root);
+            s.persist(prov);
+            tx.commit();
+        }
 
         si = new IServerInstance() {
             @Override public String getServerURL() { return "https://example.com"; }
-            @Override public Session getDatabaseSession() { return null; }
+            @Override public Session getDatabaseSession() { return hu.getSessionFactory().openSession(); }
             @Override public ICryptoStoreManager getCryptoStoreManager() { return csm; }
-            @Override public de.morihofi.acmeserver.types.config.Config getAppConfig() { return null; }
+            @Override public de.morihofi.acmeserver.types.config.Config getAppConfig() { return cfg; }
             @Override public de.morihofi.acmeserver.types.intf.INonceManager getNonceManager() { return null; }
-            @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+            @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return root; }
             @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
             @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
         };
-
-        X509CRL crl = CrlGenerator.generate(CrlGenerator.Request.builder()
-                .revokedCertificates(Collections.emptyList())
-                .caCert(interCert)
-                .caPrivateKey(interKey.getPrivate())
-                .updateMinutes(5)
-                .build());
-        CrlStore.entryMap.put("test", new CrlStore.CrlEntry(LocalTime.now(), crl));
 
         endpoint = new OcspEndpointGet(si);
     }
 
     @AfterEach
     void cleanup() {
-        CrlStore.entryMap.clear();
+        if (hu != null && hu.getSessionFactory() != null) {
+            hu.getSessionFactory().close();
+        }
     }
 
     @Test

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspHelperTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspHelperTest.java
@@ -4,16 +4,25 @@ import com.google.common.jimfs.Jimfs;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
 import de.morihofi.acmeserver.cryptography.keys.KeyPairGenerator;
 import de.morihofi.acmeserver.cryptography.keystore.CryptoStoreManager;
-import de.morihofi.acmeserver.cryptography.revoke.CrlGenerator;
-import de.morihofi.acmeserver.types.cryptography.revoke.RevokedCertificate;
+import de.morihofi.acmeserver.cryptography.ocsp.OcspHelper;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisionerDomainNameRestriction;
 import de.morihofi.acmeserver.types.database.entities.CertificateConfig;
 import de.morihofi.acmeserver.types.database.entities.CertificateExpiration;
 import de.morihofi.acmeserver.types.database.entities.CertificateMetadata;
+import de.morihofi.acmeserver.types.database.entities.ProvisionerMeta;
+import de.morihofi.acmeserver.types.database.entities.RootCa;
+import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import de.morihofi.acmeserver.types.database.entities.RsaCertificateAlgorithm;
+import de.morihofi.acmeserver.types.config.Config;
+import de.morihofi.acmeserver.types.config.DatabaseConfig;
 import de.morihofi.acmeserver.types.cryptography.keystore.PKCS12KeyStoreConfig;
 import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import de.morihofi.acmeserver.core.database.HibernateUtil;
+import org.hibernate.Transaction;
 import org.bouncycastle.cert.ocsp.BasicOCSPResp;
 import org.bouncycastle.cert.ocsp.OCSPResp;
 import org.bouncycastle.cert.ocsp.RevokedStatus;
@@ -26,11 +35,8 @@ import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.Security;
-import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
-import java.time.LocalTime;
 import java.util.Collections;
-import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -48,6 +54,7 @@ class OcspHelperTest {
     }
 
     private CryptoStoreManager csm;
+    private HibernateUtil hu;
     private IServerInstance si;
     private AcmeProvisioner prov;
 
@@ -76,32 +83,56 @@ class OcspHelperTest {
         csm.getKeyStore().setKeyEntry(csm.getKeyStoreAliasForProvisionerIntermediate("test"),
                 interKey.getPrivate(), "".toCharArray(), new java.security.cert.Certificate[]{interCert});
 
+        Config cfg = new Config();
+        DatabaseConfig db = new DatabaseConfig();
+        db.setJdbcUrl("jdbc:h2:mem:" + java.util.UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        db.setUser("sa");
+        db.setPassword("");
+        cfg.setDatabase(db);
+
+        hu = new HibernateUtil(cfg, true);
+
+        RootCa root = new RootCa();
+        root.setCertificateConfig(cfg("root"));
+        root.setInternalUuid("root");
+
         prov = new AcmeProvisioner();
         prov.setName("test");
+        prov.setRootCa(root);
+        prov.setMeta(new ProvisionerMeta("", ""));
+        prov.setCertificateConfig(cfg("inter"));
+        prov.setIssuedCertificateExpiration(new CertificateExpiration(0, 0, 1));
+        prov.setWildcardAllowed(false);
+        prov.setIpAllowed(true);
+        AcmeProvisionerDomainNameRestriction r = new AcmeProvisionerDomainNameRestriction();
+        r.setEnabled(false);
+        r.setMustEndWith(Collections.emptyList());
+        prov.setAcmeProvisionerDomainNameRestriction(r);
+
+        try (Session s = hu.getSessionFactory().openSession()) {
+            Transaction tx = s.beginTransaction();
+            s.persist(root);
+            s.persist(prov);
+            tx.commit();
+        }
 
         si = new IServerInstance() {
             @Override public String getServerURL() { return "https://example.com"; }
-            @Override public Session getDatabaseSession() { return null; }
+            @Override public Session getDatabaseSession() { return hu.getSessionFactory().openSession(); }
             @Override public ICryptoStoreManager getCryptoStoreManager() { return csm; }
-            @Override public de.morihofi.acmeserver.types.config.Config getAppConfig() { return null; }
+            @Override public de.morihofi.acmeserver.types.config.Config getAppConfig() { return cfg; }
             @Override public de.morihofi.acmeserver.types.intf.INonceManager getNonceManager() { return null; }
-            @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+            @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return root; }
             @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
             @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
         };
-
-        X509CRL crl = CrlGenerator.generate(CrlGenerator.Request.builder()
-                .revokedCertificates(Collections.emptyList())
-                .caCert(interCert)
-                .caPrivateKey(interKey.getPrivate())
-                .updateMinutes(5)
-                .build());
-        CrlStore.entryMap.put("test", new CrlStore.CrlEntry(LocalTime.now(), crl));
     }
 
     @AfterEach
     void cleanup() {
-        CrlStore.entryMap.clear();
+        if (hu != null && hu.getSessionFactory() != null) {
+            hu.getSessionFactory().close();
+        }
     }
 
     @Test
@@ -116,16 +147,25 @@ class OcspHelperTest {
     @Test
     @DisplayName("OCSP response revoked for revoked cert")
     void testOcspRevoked() throws Exception {
-        KeyPair intKey = csm.getIntermediateCerificateAuthorityKeyPair("test");
-        X509Certificate intCert = csm.getX509CertificateForProvisioner("test");
-        RevokedCertificate rc = new RevokedCertificate(BigInteger.TEN, new Date(), 0);
-        X509CRL crl = CrlGenerator.generate(CrlGenerator.Request.builder()
-                .revokedCertificate(rc)
-                .caCert(intCert)
-                .caPrivateKey(intKey.getPrivate())
-                .updateMinutes(5)
-                .build());
-        CrlStore.entryMap.put("test", new CrlStore.CrlEntry(LocalTime.now(), crl));
+        try (Session s = si.getDatabaseSession()) {
+            Transaction tx = s.beginTransaction();
+
+            AcmeAccount acc = new AcmeAccount();
+            acc.setAccountId("acc");
+            acc.setPublicKeyPEM("");
+            acc.setEmails(Collections.emptyList());
+            acc.setAcmeProvisioner(prov);
+            s.persist(acc);
+
+            AcmeOrder order = new AcmeOrder();
+            order.setAccount(acc);
+            order.setCertificateSerialNumber(BigInteger.TEN);
+            order.setRevokeStatusCode(0);
+            order.setRevokeTimestamp(new java.sql.Timestamp(System.currentTimeMillis()));
+            s.persist(order);
+
+            tx.commit();
+        }
 
         OCSPResp resp = OcspHelper.processOCSPRequest(BigInteger.TEN, prov, si);
         BasicOCSPResp basic = (BasicOCSPResp) resp.getResponseObject();

--- a/acmeserver-cryptography/src/main/java/de/morihofi/acmeserver/cryptography/ocsp/OcspHelper.java
+++ b/acmeserver-cryptography/src/main/java/de/morihofi/acmeserver/cryptography/ocsp/OcspHelper.java
@@ -14,19 +14,22 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package de.morihofi.acmeserver.core.certificate.revokeDistribution;
+package de.morihofi.acmeserver.cryptography.ocsp;
 
 
 import de.morihofi.acmeserver.cryptography.keys.KeyHelper;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
 import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.cryptography.revoke.RevokedCertificate;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.ocsp.*;
+import org.bouncycastle.cert.ocsp.RevokedStatus;
 import org.bouncycastle.operator.DigestCalculator;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -47,14 +50,14 @@ import java.util.Date;
 public class OcspHelper {
 
     /**
-     * Processes an OCSP (Online Certificate Status Protocol) request for a given certificate serial number. This method checks the status
-     * of the certificate using the current Certificate Revocation List (CRL) and generates an OCSP response accordingly.
+     * Processes an OCSP (Online Certificate Status Protocol) request for a given
+     * certificate serial number. The certificate status is resolved directly from
+     * the database and the appropriate OCSP response is generated.
      *
      * @param serialNumber The serial number of the certificate for which the OCSP response is requested.
      * @param provisioner  Provisioner Instance
      * @return An OCSPResp object representing the OCSP response for the given certificate.
      * @throws OCSPException                if there is an issue with OCSP processing.
-     * @throws CRLException                 if there is an issue with CRL processing.
      * @throws CertificateEncodingException if there is an issue with encoding certificates.
      * @throws OperatorCreationException    if there is an issue with operator creation.
      * @throws NoSuchAlgorithmException     if there is an issue with signing algorithm.
@@ -62,10 +65,16 @@ public class OcspHelper {
      * @throws KeyStoreException            if there is an issue with the keystore.
      */
     public static OCSPResp processOCSPRequest(BigInteger serialNumber, @NonNull AcmeProvisioner provisioner, @NonNull IServerInstance serverInstance) throws
-            OCSPException, CRLException, CertificateEncodingException, OperatorCreationException, KeyStoreException,
+            OCSPException, CertificateEncodingException, OperatorCreationException, KeyStoreException,
             UnrecoverableKeyException, NoSuchAlgorithmException {
 
-        CertificateStatus certStatus = CrlStore.getCertificateStatus(serialNumber, provisioner.getName());
+        RevokedCertificate rc = AcmeOrder.getRevokedCertificate(serialNumber, provisioner.getName(), serverInstance);
+        CertificateStatus certStatus;
+        if (rc != null) {
+            certStatus = new RevokedStatus(rc.revocationDate(), rc.revocationReason());
+        } else {
+            certStatus = CertificateStatus.GOOD;
+        }
 
         log.info("Status for serial number {} is: {}", serialNumber, (certStatus != CertificateStatus.GOOD ? "revoked" : "valid"));
 

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/database/entities/AcmeOrder.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/database/entities/AcmeOrder.java
@@ -151,6 +151,51 @@ public class AcmeOrder implements Serializable {
     }
 
     /**
+     * Retrieves the revocation information for a specific certificate serial
+     * number. If the certificate is revoked, a {@link RevokedCertificate}
+     * instance containing the revocation date and reason is returned. Otherwise
+     * {@code null} is returned.
+     *
+     * @param serialNumber    Serial number of the certificate.
+     * @param provisionerName Name of the provisioner issuing the certificate.
+     * @param serverInstance  Server instance for database access.
+     * @return Revocation data or {@code null} if the certificate is not revoked
+     *         or could not be found.
+     */
+    public static RevokedCertificate getRevokedCertificate(BigInteger serialNumber,
+                                                           String provisionerName,
+                                                           IServerInstance serverInstance) {
+        RevokedCertificate rc = null;
+
+        try (Session session = serverInstance.getDatabaseSession()) {
+            Transaction transaction = session.beginTransaction();
+
+            Query<AcmeOrder> query = session.createQuery(
+                    "FROM AcmeOrder a WHERE a.certificateSerialNumber = :serialNumber "
+                            + "AND a.account.acmeProvisioner.name = :provisionerName",
+                    AcmeOrder.class);
+            query.setParameter("serialNumber", serialNumber);
+            query.setParameter("provisionerName", provisionerName);
+            AcmeOrder result = query.setMaxResults(1).uniqueResult();
+
+            if (result != null
+                    && result.getRevokeStatusCode() != null
+                    && result.getRevokeTimestamp() != null) {
+                rc = new RevokedCertificate(
+                        result.getCertificateSerialNumber(),
+                        result.getRevokeTimestamp(),
+                        result.getRevokeStatusCode());
+            }
+
+            transaction.commit();
+        } catch (Exception e) {
+            log.error("Unable to get revoked certificate for serial number {}", serialNumber, e);
+        }
+
+        return rc;
+    }
+
+    /**
      * Revokes an ACME (Automated Certificate Management Environment) certificate associated with an ACME identifier.
      *
      * @param order          The ACME order for which the certificate is to be revoked.


### PR DESCRIPTION
## Summary
- move `OcspHelper` from core into cryptography module
- query certificate status directly from database
- adapt endpoints to new helper location
- update tests to use in-memory database

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684ac20f57b88322b34b0d2b8fd8ba77