### PR TITLE
Implement improved event bus

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/Main.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/Main.java
@@ -35,6 +35,10 @@ import de.morihofi.acmeserver.utils.cli.CLIArgument;
 import de.morihofi.acmeserver.utils.meta.BuildMetadataImpl;
 import de.morihofi.acmeserver.utils.network.http.NetworkClient;
 import de.morihofi.acmeserver.utils.path.AppDirectoryHelper;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.ServerInitializedEvent;
+import de.morihofi.acmeserver.types.events.ServerStartedEvent;
+import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -152,11 +156,15 @@ public class Main {
 
         Config config = loadServerConfiguration();
         serverInstance = getServerInstance(config, debug, CONFIG_PATH);
+        GlobalEventBus.publish(new ServerInitializedEvent(serverInstance));
 
 
         WebServer ws = new WebServer(serverInstance);
         try {
             ws.startServer();
+            GlobalEventBus.publish(new ServerStartedEvent(serverInstance));
+            Runtime.getRuntime().addShutdownHook(new Thread(() ->
+                    GlobalEventBus.publish(new ServerShutdownEvent(serverInstance))));
         } catch (Exception ex) {
             log.error("Server startup failed", ex);
             System.exit(1);

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/Main.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/Main.java
@@ -35,7 +35,7 @@ import de.morihofi.acmeserver.utils.cli.CLIArgument;
 import de.morihofi.acmeserver.utils.meta.BuildMetadataImpl;
 import de.morihofi.acmeserver.utils.network.http.NetworkClient;
 import de.morihofi.acmeserver.utils.path.AppDirectoryHelper;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.ServerInitializedEvent;
 import de.morihofi.acmeserver.types.events.ServerStartedEvent;
 import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
@@ -155,16 +155,17 @@ public class Main {
 
 
         Config config = loadServerConfiguration();
-        serverInstance = getServerInstance(config, debug, CONFIG_PATH);
-        GlobalEventBus.publish(new ServerInitializedEvent(serverInstance));
+        EventBus eventBus = new EventBus();
+        serverInstance = getServerInstance(config, debug, CONFIG_PATH, eventBus);
+        eventBus.publish(new ServerInitializedEvent(serverInstance));
 
 
         WebServer ws = new WebServer(serverInstance);
         try {
             ws.startServer();
-            GlobalEventBus.publish(new ServerStartedEvent(serverInstance));
+            eventBus.publish(new ServerStartedEvent(serverInstance));
             Runtime.getRuntime().addShutdownHook(new Thread(() ->
-                    GlobalEventBus.publish(new ServerShutdownEvent(serverInstance))));
+                    eventBus.publish(new ServerShutdownEvent(serverInstance))));
         } catch (Exception ex) {
             log.error("Server startup failed", ex);
             System.exit(1);
@@ -173,7 +174,7 @@ public class Main {
     }
 
 
-    public static IServerInstance getServerInstance(Config config, boolean debug, Path configPath) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException, NoSuchProviderException, ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException, InvalidAlgorithmParameterException, OperatorCreationException, UnrecoverableKeyException {
+    public static IServerInstance getServerInstance(Config config, boolean debug, Path configPath, EventBus eventBus) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException, NoSuchProviderException, ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException, InvalidAlgorithmParameterException, OperatorCreationException, UnrecoverableKeyException {
         if (Objects.equals(System.getenv("DEBUG"), "TRUE")) {
             debug = true;
             log.info("Debug mode activated by DEBUG environment variable set to TRUE");
@@ -199,11 +200,11 @@ public class Main {
         };
 
         log.info("Initializing database ...");
-        HibernateUtil hibernateUtil = new HibernateUtil(config, debug);
+        HibernateUtil hibernateUtil = new HibernateUtil(config, debug, eventBus);
         hibernateUtil.initDatabase();
 
         log.info("Initializing certificate authorities ...");
-        RootCa root = CaInitHelper.initializeCA(hibernateUtil, cryptoStoreManager);
+        RootCa root = CaInitHelper.initializeCA(hibernateUtil, cryptoStoreManager, eventBus);
 
         log.info("Creating new server instance ...");
         return new ServerInstance(
@@ -213,9 +214,10 @@ public class Main {
                 cryptoStoreManager,
                 new NetworkClient(config.getNetwork()),
                 hibernateUtil,
-                new NonceManager(hibernateUtil, debug),
+                new NonceManager(hibernateUtil, debug, eventBus),
                 root,
-                BuildMetadataImpl.getInstance()
+                BuildMetadataImpl.getInstance(),
+                eventBus
         );
     }
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/ServerInstance.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/ServerInstance.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import de.morihofi.acmeserver.types.events.EventBus;
 import org.hibernate.Session;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,7 +42,7 @@ import java.nio.file.Path;
 public class ServerInstance implements IServerInstance {
 
 
-    public ServerInstance(@NonNull Config appConfig, @NonNull Path appConfigPath, boolean debug, @NonNull CryptoStoreManager cryptoStoreManager, @NonNull INetworkClient networkClient, @NonNull HibernateUtil hibernateUtil, @NonNull INonceManager nonceManager, @NonNull RootCa rootCa, @NonNull BuildMetadata buildMetadata) {
+    public ServerInstance(@NonNull Config appConfig, @NonNull Path appConfigPath, boolean debug, @NonNull CryptoStoreManager cryptoStoreManager, @NonNull INetworkClient networkClient, @NonNull HibernateUtil hibernateUtil, @NonNull INonceManager nonceManager, @NonNull RootCa rootCa, @NonNull BuildMetadata buildMetadata, @NonNull EventBus eventBus) {
         this.appConfig = appConfig;
         this.appConfigPath = appConfigPath;
         this.debug = debug;
@@ -51,6 +52,7 @@ public class ServerInstance implements IServerInstance {
         this.nonceManager = nonceManager;
         this.rootCa = rootCa;
         this.buildMetadata = buildMetadata;
+        this.eventBus = eventBus;
 
         // Clear sensitive passwords from in memory config to avoid accidental exposure
         this.appConfig.getDatabase().setPassword(null);
@@ -105,6 +107,9 @@ public class ServerInstance implements IServerInstance {
     @NonNull
     private final BuildMetadata buildMetadata;
 
+    @NonNull
+    private final EventBus eventBus;
+
     /**
      * Retrieves the server URL constructed from the application's configuration. This method combines the DNS name and HTTPS port specified
      * in the app configuration to form the complete server URL.
@@ -128,6 +133,11 @@ public class ServerInstance implements IServerInstance {
 
         return getHibernateUtil().getSessionFactory().openSession();
     }
+    @Override
+    public EventBus getEventBus() {
+        return eventBus;
+    }
+
 
 
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
@@ -44,7 +44,7 @@ import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
 import de.morihofi.acmeserver.core.tools.network.logging.HTTPAccessLogger;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.database.entities.HttpNonces;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.BeforeAcmeApiRequestEvent;
 import de.morihofi.acmeserver.types.events.AcmeExceptionEvent;
 import io.javalin.Javalin;
@@ -97,8 +97,8 @@ public class WebServer {
      */
     public WebServer(IServerInstance serverInstance) throws IOException {
         this.serverInstance = serverInstance;
-        this.httpAccessLogger = new HTTPAccessLogger(serverInstance.getAppConfig());
-        this.certificateRenewManager = new CertificateRenewManager(serverInstance.getCryptoStoreManager());
+        this.httpAccessLogger = new HTTPAccessLogger(serverInstance.getAppConfig(), serverInstance.getEventBus());
+        this.certificateRenewManager = new CertificateRenewManager(serverInstance.getCryptoStoreManager(), serverInstance.getEventBus());
     }
 
     /**
@@ -144,7 +144,7 @@ public class WebServer {
             ctx.json(exception.getErrorResponse());
             log.error("ACME Exception thrown {} : {} ({})", exception.getClass().getSimpleName(), exception.getErrorResponse().getDetail(),
                     exception.getErrorResponse().getType());
-            GlobalEventBus.publish(new AcmeExceptionEvent(exception));
+            serverInstance.getEventBus().publish(new AcmeExceptionEvent(exception));
         });
 
         // Global routes
@@ -156,7 +156,7 @@ public class WebServer {
             // Disable caching for all ACME routes
             context.header("Cache-Control", "public, max-age=0, no-cache");
 
-            GlobalEventBus.publish(new BeforeAcmeApiRequestEvent(context.path(), context.method().toString()));
+            serverInstance.getEventBus().publish(new BeforeAcmeApiRequestEvent(context.path(), context.method().toString()));
 
             AcmeProvisioner provisioner = AbstractAcmeEndpoint.getProvisionerFromJavalin(serverInstance, context);
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
@@ -44,6 +44,9 @@ import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
 import de.morihofi.acmeserver.core.tools.network.logging.HTTPAccessLogger;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.database.entities.HttpNonces;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.BeforeAcmeApiRequestEvent;
+import de.morihofi.acmeserver.types.events.AcmeExceptionEvent;
 import io.javalin.Javalin;
 import io.javalin.http.HandlerType;
 import io.javalin.http.staticfiles.Location;
@@ -141,6 +144,7 @@ public class WebServer {
             ctx.json(exception.getErrorResponse());
             log.error("ACME Exception thrown {} : {} ({})", exception.getClass().getSimpleName(), exception.getErrorResponse().getDetail(),
                     exception.getErrorResponse().getType());
+            GlobalEventBus.publish(new AcmeExceptionEvent(exception));
         });
 
         // Global routes
@@ -151,6 +155,8 @@ public class WebServer {
         app.before("/acme/{provisioner}/*", context -> {
             // Disable caching for all ACME routes
             context.header("Cache-Control", "public, max-age=0, no-cache");
+
+            GlobalEventBus.publish(new BeforeAcmeApiRequestEvent(context.path(), context.method().toString()));
 
             AcmeProvisioner provisioner = AbstractAcmeEndpoint.getProvisionerFromJavalin(serverInstance, context);
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/NewOrderEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/NewOrderEndpoint.java
@@ -36,7 +36,7 @@ import de.morihofi.acmeserver.utils.datetime.DateTools;
 import de.morihofi.acmeserver.utils.regex.DomainValidator;
 import de.morihofi.acmeserver.utils.regex.IpValidator;
 import io.javalin.http.Context;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.NewAcmeOrderEvent;
 
 import lombok.NonNull;
@@ -211,7 +211,7 @@ public class NewOrderEndpoint extends AbstractAcmeEndpoint {
             }
 
             transaction.commit();
-            GlobalEventBus.publish(new NewAcmeOrderEvent(order));
+            getServerInstance().getEventBus().publish(new NewAcmeOrderEvent(order));
         }
 
         // FIXME Send E-Mail/Notification if order was created

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/NewOrderEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/NewOrderEndpoint.java
@@ -36,6 +36,8 @@ import de.morihofi.acmeserver.utils.datetime.DateTools;
 import de.morihofi.acmeserver.utils.regex.DomainValidator;
 import de.morihofi.acmeserver.utils.regex.IpValidator;
 import io.javalin.http.Context;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.NewAcmeOrderEvent;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -209,6 +211,7 @@ public class NewOrderEndpoint extends AbstractAcmeEndpoint {
             }
 
             transaction.commit();
+            GlobalEventBus.publish(new NewAcmeOrderEvent(order));
         }
 
         // FIXME Send E-Mail/Notification if order was created

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/AccountEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/AccountEndpoint.java
@@ -27,6 +27,8 @@ import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEAccountNotFoundException;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEInvalidContactException;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.AcmeAccountDeactivatedEvent;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.regex.EmailValidator;
 import io.javalin.http.Context;
@@ -116,6 +118,9 @@ public class AccountEndpoint extends AbstractAcmeEndpoint {
             }
 
             transaction.commit();
+            if (account.isDeactivated()) {
+                GlobalEventBus.publish(new AcmeAccountDeactivatedEvent(account));
+            }
         }
 
         ctx.header("Content-Type", "application/json");

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/AccountEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/AccountEndpoint.java
@@ -27,7 +27,7 @@ import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEAccountNotFoundException;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEInvalidContactException;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.AcmeAccountDeactivatedEvent;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.regex.EmailValidator;
@@ -119,7 +119,7 @@ public class AccountEndpoint extends AbstractAcmeEndpoint {
 
             transaction.commit();
             if (account.isDeactivated()) {
-                GlobalEventBus.publish(new AcmeAccountDeactivatedEvent(account));
+                getServerInstance().getEventBus().publish(new AcmeAccountDeactivatedEvent(account));
             }
         }
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/NewAccountEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/NewAccountEndpoint.java
@@ -35,7 +35,7 @@ import de.morihofi.acmeserver.cryptography.pem.PemUtil;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.regex.EmailValidator;
 import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.AcmeAccountCreatedEvent;
 import io.javalin.http.Context;
 
@@ -134,7 +134,7 @@ public class NewAccountEndpoint extends AbstractAcmeEndpoint {
             session.persist(account);
             transaction.commit();
             log.info("New ACME account created with account id {}", accountId);
-            GlobalEventBus.publish(new AcmeAccountCreatedEvent(account));
+            getServerInstance().getEventBus().publish(new AcmeAccountCreatedEvent(account));
         } catch (Exception e) {
             log.error("Unable to create new ACME account", e);
             throw new ACMEServerInternalException(e.getMessage());

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/NewAccountEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/account/NewAccountEndpoint.java
@@ -35,6 +35,8 @@ import de.morihofi.acmeserver.cryptography.pem.PemUtil;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.regex.EmailValidator;
 import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.AcmeAccountCreatedEvent;
 import io.javalin.http.Context;
 
 import lombok.extern.slf4j.Slf4j;
@@ -132,6 +134,7 @@ public class NewAccountEndpoint extends AbstractAcmeEndpoint {
             session.persist(account);
             transaction.commit();
             log.info("New ACME account created with account id {}", accountId);
+            GlobalEventBus.publish(new AcmeAccountCreatedEvent(account));
         } catch (Exception e) {
             log.error("Unable to create new ACME account", e);
             throw new ACMEServerInternalException(e.getMessage());

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/ChallengeCallbackEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/ChallengeCallbackEndpoint.java
@@ -33,7 +33,7 @@ import de.morihofi.acmeserver.types.exception.exceptions.ACMEResourceNotFoundExc
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.datetime.DateTools;
 import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.BeforeChallengeEvent;
 import de.morihofi.acmeserver.types.events.AfterChallengeEvent;
 import de.morihofi.acmeserver.types.api.acme.challenge.AcmeChallengeType;
@@ -99,7 +99,7 @@ public class ChallengeCallbackEndpoint extends AbstractAcmeEndpoint {
         AcmeOrderIdentifierChallenge.markChallenge(AcmeStatus.PROCESSING, challengeId, getServerInstance());
 
         AcmeChallengeType typeEnum = "http-01".equals(challengeType) ? AcmeChallengeType.HTTP_01 : AcmeChallengeType.DNS_01;
-        GlobalEventBus.publish(new BeforeChallengeEvent(typeEnum, challengeId));
+        getServerInstance().getEventBus().publish(new BeforeChallengeEvent(typeEnum, challengeId));
 
         ChallengeResult result = switch (challengeType) {
             case "http-01" -> HTTPChallenge.check(
@@ -131,7 +131,7 @@ public class ChallengeCallbackEndpoint extends AbstractAcmeEndpoint {
             throw new ACMEConnectionErrorException(result.errorReason());
         }
 
-        GlobalEventBus.publish(new AfterChallengeEvent(typeEnum, challengeId, result.successful()));
+        getServerInstance().getEventBus().publish(new AfterChallengeEvent(typeEnum, challengeId, result.successful()));
 
         // Reload identifier, e.g., host has validated
         identifierChallenge = AcmeOrderIdentifierChallenge.getACMEIdentifierChallenge(challengeId, getServerInstance());

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/ChallengeCallbackEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/challenge/ChallengeCallbackEndpoint.java
@@ -33,6 +33,10 @@ import de.morihofi.acmeserver.types.exception.exceptions.ACMEResourceNotFoundExc
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.datetime.DateTools;
 import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.BeforeChallengeEvent;
+import de.morihofi.acmeserver.types.events.AfterChallengeEvent;
+import de.morihofi.acmeserver.types.api.acme.challenge.AcmeChallengeType;
 import io.javalin.http.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -94,6 +98,9 @@ public class ChallengeCallbackEndpoint extends AbstractAcmeEndpoint {
         // move challenge into processing state before performing validation
         AcmeOrderIdentifierChallenge.markChallenge(AcmeStatus.PROCESSING, challengeId, getServerInstance());
 
+        AcmeChallengeType typeEnum = "http-01".equals(challengeType) ? AcmeChallengeType.HTTP_01 : AcmeChallengeType.DNS_01;
+        GlobalEventBus.publish(new BeforeChallengeEvent(typeEnum, challengeId));
+
         ChallengeResult result = switch (challengeType) {
             case "http-01" -> HTTPChallenge.check(
                     identifierChallenge.getAuthorizationToken(),
@@ -123,6 +130,8 @@ public class ChallengeCallbackEndpoint extends AbstractAcmeEndpoint {
             log.error("Throwing API error: Host verification failed with method {}", challengeType);
             throw new ACMEConnectionErrorException(result.errorReason());
         }
+
+        GlobalEventBus.publish(new AfterChallengeEvent(typeEnum, challengeId, result.successful()));
 
         // Reload identifier, e.g., host has validated
         identifierChallenge = AcmeOrderIdentifierChallenge.getACMEIdentifierChallenge(challengeId, getServerInstance());

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/security/NonceManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/security/NonceManager.java
@@ -22,7 +22,7 @@ import de.morihofi.acmeserver.core.database.HibernateUtil;
 import de.morihofi.acmeserver.types.database.entities.HttpNonces;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEBadNonceException;
 import de.morihofi.acmeserver.types.intf.INonceManager;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.AcmeNonceRedeemedEvent;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +45,9 @@ public class NonceManager implements INonceManager {
     */
     private final HibernateUtil hibernateUtil;
 
+    /** Event bus for publishing nonce events. */
+    private final EventBus eventBus;
+
     /**
      * Debug mode flag. If true, nonce protection is disabled for debugging purposes.
      */
@@ -56,9 +59,10 @@ public class NonceManager implements INonceManager {
      * @param hibernateUtil The Hibernate utility for managing database operations.
      * @param debug         The debug mode flag.
      */
-    public NonceManager(HibernateUtil hibernateUtil, boolean debug) {
+    public NonceManager(HibernateUtil hibernateUtil, boolean debug, EventBus eventBus) {
         this.hibernateUtil = hibernateUtil;
         this.debug = debug;
+        this.eventBus = eventBus;
     }
 
 
@@ -115,7 +119,7 @@ public class NonceManager implements INonceManager {
 
             // Apply
             transaction.commit();
-            GlobalEventBus.publish(new AcmeNonceRedeemedEvent(nonce));
+            eventBus.publish(new AcmeNonceRedeemedEvent(nonce));
 
             return false;
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/security/NonceManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/security/NonceManager.java
@@ -22,6 +22,8 @@ import de.morihofi.acmeserver.core.database.HibernateUtil;
 import de.morihofi.acmeserver.types.database.entities.HttpNonces;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEBadNonceException;
 import de.morihofi.acmeserver.types.intf.INonceManager;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.AcmeNonceRedeemedEvent;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
@@ -113,6 +115,7 @@ public class NonceManager implements INonceManager {
 
             // Apply
             transaction.commit();
+            GlobalEventBus.publish(new AcmeNonceRedeemedEvent(nonce));
 
             return false;
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuer.java
@@ -29,7 +29,7 @@ import de.morihofi.acmeserver.cryptography.pem.PemUtil;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
 import de.morihofi.acmeserver.utils.network.dns.CAAValidator;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMECaaException;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.BeforeAcmeCertificateCreatedEvent;
 import de.morihofi.acmeserver.types.events.AcmeCertificateCreatedEvent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -108,7 +108,7 @@ public class CertificateIssuer {
             }
         }
 
-        GlobalEventBus.publish(new BeforeAcmeCertificateCreatedEvent(order));
+        serverInstance.getEventBus().publish(new BeforeAcmeCertificateCreatedEvent(order));
 
         /*
             We just use the DNS Domain Names (Subject Alternative Name) and the public key of the CSR. We're not using
@@ -154,7 +154,7 @@ public class CertificateIssuer {
         session.merge(order);
 
         transaction.commit();
-        GlobalEventBus.publish(new AcmeCertificateCreatedEvent(order, acmeGeneratedCertificate));
+        serverInstance.getEventBus().publish(new AcmeCertificateCreatedEvent(order, acmeGeneratedCertificate));
 
         log.info("Stored certificate successful");
     }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuer.java
@@ -29,6 +29,9 @@ import de.morihofi.acmeserver.cryptography.pem.PemUtil;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
 import de.morihofi.acmeserver.utils.network.dns.CAAValidator;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMECaaException;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.BeforeAcmeCertificateCreatedEvent;
+import de.morihofi.acmeserver.types.events.AcmeCertificateCreatedEvent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -105,6 +108,8 @@ public class CertificateIssuer {
             }
         }
 
+        GlobalEventBus.publish(new BeforeAcmeCertificateCreatedEvent(order));
+
         /*
             We just use the DNS Domain Names (Subject Alternative Name) and the public key of the CSR. We're not using
             the Basic Constrain etc., because this is defined by the CA that we are
@@ -149,6 +154,7 @@ public class CertificateIssuer {
         session.merge(order);
 
         transaction.commit();
+        GlobalEventBus.publish(new AcmeCertificateCreatedEvent(order, acmeGeneratedCertificate));
 
         log.info("Stored certificate successful");
     }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/database/HibernateUtil.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/database/HibernateUtil.java
@@ -27,7 +27,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.reflections.Reflections;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
 
 import java.io.IOException;
@@ -44,10 +44,12 @@ public class HibernateUtil {
 
     private final Config appConfig;
     private final boolean debug;
+    private final EventBus eventBus;
 
-    public HibernateUtil(@NonNull Config appConfig, boolean debug) throws IOException {
+    public HibernateUtil(@NonNull Config appConfig, boolean debug, EventBus eventBus) throws IOException {
         this.appConfig = appConfig;
         this.debug = debug;
+        this.eventBus = eventBus;
         initDatabase();
     }
 
@@ -75,7 +77,7 @@ public class HibernateUtil {
                 throw new ExceptionInInitializerError(e);
             }
 
-            GlobalEventBus.subscribe(ServerShutdownEvent.class, event -> {
+            eventBus.subscribe(ServerShutdownEvent.class, event -> {
                 Thread.currentThread().setName("Database Shutdown Thread");
                 shutdown();
             });

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/database/HibernateUtil.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/database/HibernateUtil.java
@@ -27,6 +27,8 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.reflections.Reflections;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -73,14 +75,9 @@ public class HibernateUtil {
                 throw new ExceptionInInitializerError(e);
             }
 
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    this.setName("Database Shutdown Thread");
-                    super.run();
-
-                    shutdown();
-                }
+            GlobalEventBus.subscribe(ServerShutdownEvent.class, event -> {
+                Thread.currentThread().setName("Database Shutdown Thread");
+                shutdown();
             });
         }
     }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/helper/cert/CaInitHelper.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/helper/cert/CaInitHelper.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.ProvisionerCreatedEvent;
 
 import java.io.IOException;
@@ -44,7 +44,7 @@ public class CaInitHelper {
     /**
      * Initializes the Certificate Authority (CA) by generating or loading the CA certificate and key pair.
      */
-    public static RootCa initializeCA(@NonNull HibernateUtil h, ICryptoStoreManager cryptoStoreManager) throws NoSuchAlgorithmException, CertificateException, IOException, OperatorCreationException,
+    public static RootCa initializeCA(@NonNull HibernateUtil h, ICryptoStoreManager cryptoStoreManager, EventBus eventBus) throws NoSuchAlgorithmException, CertificateException, IOException, OperatorCreationException,
             NoSuchProviderException, KeyStoreException, UnrecoverableKeyException {
         try (Session session = h.getSessionFactory().openSession()) {
 
@@ -98,7 +98,7 @@ public class CaInitHelper {
 
             Transaction transaction = session.beginTransaction();
             if (session.createQuery("FROM AcmeProvisioner", AcmeProvisioner.class).list().isEmpty()) {
-                createDefaultProvisioner(session, cryptoStoreManager, rootCaEntity, caKeyPair, caCertificate);
+                createDefaultProvisioner(session, cryptoStoreManager, rootCaEntity, caKeyPair, caCertificate, eventBus);
             }
             transaction.commit();
 
@@ -108,7 +108,8 @@ public class CaInitHelper {
     }
 
     private static void createDefaultProvisioner(Session session, ICryptoStoreManager cryptoStoreManager,
-                                                 RootCa rootCa, KeyPair caKeyPair, X509Certificate caCertificate)
+                                                 RootCa rootCa, KeyPair caKeyPair, X509Certificate caCertificate,
+                                                 EventBus eventBus)
             throws NoSuchAlgorithmException, CertificateException, KeyStoreException, OperatorCreationException, IOException, NoSuchProviderException {
 
         log.info("Creating default provisioner");
@@ -154,6 +155,6 @@ public class CaInitHelper {
         provisioner.setAcmeProvisionerDomainNameRestriction(restr);
 
         session.persist(provisioner);
-        GlobalEventBus.publish(new ProvisionerCreatedEvent(provisioner));
+        eventBus.publish(new ProvisionerCreatedEvent(provisioner));
     }
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/helper/cert/CaInitHelper.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/helper/cert/CaInitHelper.java
@@ -26,6 +26,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.ProvisionerCreatedEvent;
 
 import java.io.IOException;
 import java.security.*;
@@ -152,5 +154,6 @@ public class CaInitHelper {
         provisioner.setAcmeProvisionerDomainNameRestriction(restr);
 
         session.persist(provisioner);
+        GlobalEventBus.publish(new ProvisionerCreatedEvent(provisioner));
     }
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/CertificateRenewManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/CertificateRenewManager.java
@@ -21,7 +21,7 @@ import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.cryptography.keystore.KeyStoreUtil;
 import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.utils.lambda.TriFunction;
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.ProvisionerCertificateRenewedEvent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
@@ -49,6 +49,7 @@ public class CertificateRenewManager {
 
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private final ICryptoStoreManager cryptoStoreManager;
+    private final EventBus eventBus;
     private final Map<String, RenewEntry> renewMap = Collections.synchronizedMap(new HashMap<>());
 
     /**
@@ -56,8 +57,9 @@ public class CertificateRenewManager {
      *
      * @param cryptoStoreManager The CryptoStoreManager instance used for key and certificate management.
      */
-    public CertificateRenewManager(ICryptoStoreManager cryptoStoreManager) {
+    public CertificateRenewManager(ICryptoStoreManager cryptoStoreManager, EventBus eventBus) {
         this.cryptoStoreManager = cryptoStoreManager;
+        this.eventBus = eventBus;
     }
 
     /**
@@ -155,7 +157,7 @@ public class CertificateRenewManager {
                             newCertificateData.certificateChain()
                     );
                     cryptoStoreManager.saveKeystore();
-                    GlobalEventBus.publish(new ProvisionerCertificateRenewedEvent(provisioner));
+                    eventBus.publish(new ProvisionerCertificateRenewedEvent(provisioner));
 
                     if (renewEntry.triggerAfterRegeneration != null) {
                         log.info("Running post configuration runnable");

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/CertificateRenewManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/CertificateRenewManager.java
@@ -21,6 +21,8 @@ import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.cryptography.keystore.KeyStoreUtil;
 import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.utils.lambda.TriFunction;
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.ProvisionerCertificateRenewedEvent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 
@@ -153,6 +155,7 @@ public class CertificateRenewManager {
                             newCertificateData.certificateChain()
                     );
                     cryptoStoreManager.saveKeystore();
+                    GlobalEventBus.publish(new ProvisionerCertificateRenewedEvent(provisioner));
 
                     if (renewEntry.triggerAfterRegeneration != null) {
                         log.info("Running post configuration runnable");

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/network/logging/HTTPAccessLogger.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/network/logging/HTTPAccessLogger.java
@@ -37,7 +37,7 @@ import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
 
 @Slf4j
@@ -49,10 +49,12 @@ public class HTTPAccessLogger {
     private final BlockingQueue<String> logQueue = new LinkedBlockingQueue<>();
     private final Thread logWriterThread;
     private final Path logFileDirectory;
+    private final EventBus eventBus;
 
     private volatile boolean running = true;
 
-    public HTTPAccessLogger(Config appConfig) throws IOException {
+    public HTTPAccessLogger(Config appConfig, EventBus eventBus) throws IOException {
+        this.eventBus = eventBus;
 
         String loggingDirectory = appConfig.getServer().getLoggingDirectory();
 
@@ -70,7 +72,7 @@ public class HTTPAccessLogger {
             logWriterThread.start();
 
             // Subscribe to global shutdown event
-            GlobalEventBus.subscribe(ServerShutdownEvent.class, event -> {
+            eventBus.subscribe(ServerShutdownEvent.class, event -> {
                 log.info("Shutting down HTTP Access Logger ...");
                 this.stop();
             });

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/network/logging/HTTPAccessLogger.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/network/logging/HTTPAccessLogger.java
@@ -37,6 +37,9 @@ import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import de.morihofi.acmeserver.utils.event.GlobalEventBus;
+import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
+
 @Slf4j
 public class HTTPAccessLogger {
     private static final String LOG_FORMAT = "%s - %s [%s] \"%s\" %d %d \"%s\" \"%s\"";
@@ -66,11 +69,11 @@ public class HTTPAccessLogger {
             logWriterThread.setName("HTTP Access Background Logger");
             logWriterThread.start();
 
-            // Add shutdown hook
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            // Subscribe to global shutdown event
+            GlobalEventBus.subscribe(ServerShutdownEvent.class, event -> {
                 log.info("Shutting down HTTP Access Logger ...");
                 this.stop();
-            }));
+            });
         } else {
             log.info("HTTP Access Logger deactivated, because no logging directory was set");
             logFileDirectory = null;

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/KeyChangeEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/KeyChangeEndpointTest.java
@@ -22,6 +22,7 @@ import de.morihofi.acmeserver.types.intf.network.INetworkClient;
 import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.types.intf.INonceManager;
 import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import de.morihofi.acmeserver.types.events.EventBus;
 import okhttp3.OkHttpClient;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -137,8 +138,9 @@ class KeyChangeEndpointTest {
         sc.setDnsName("example.com");
         cfg.setServer(sc);
 
-        HibernateUtil hu = new HibernateUtil(cfg, true);
-        NonceManager nm = new NonceManager(hu, true);
+        EventBus bus = new EventBus();
+        HibernateUtil hu = new HibernateUtil(cfg, true, bus);
+        NonceManager nm = new NonceManager(hu, true, bus);
 
         // create basic provisioner and root CA
         try (Session s = hu.getSessionFactory().openSession()) {
@@ -173,6 +175,7 @@ class KeyChangeEndpointTest {
             @Override public RootCa getRootCa() { return new RootCa(); }
             @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
             @Override public INetworkClient getNetworkClient() { return new DummyNetworkClient(); }
+            @Override public EventBus getEventBus() { return new EventBus(); }
         };
     }
 

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/authz/AuthzOwnershipEndpointTest.java
@@ -1,4 +1,5 @@
 package de.morihofi.acmeserver.core.api.acme.api.endpoints.authz;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 import com.google.gson.Gson;
 import de.morihofi.acmeserver.core.api.acme.api.objects.ACMERequestBody;
@@ -43,6 +44,7 @@ class AuthzOwnershipEndpointTest {
         @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
         @Override public de.morihofi.acmeserver.types.runtime.BuildMetadata getBuildMetadata() { return null; }
         @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+            @Override public EventBus getEventBus() { return new EventBus(); }
     }
 
     @Test

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/FinalizeOrderEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/FinalizeOrderEndpointTest.java
@@ -1,4 +1,5 @@
 package de.morihofi.acmeserver.core.api.acme.api.endpoints.order;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifier;
 import de.morihofi.acmeserver.types.database.entities.AcmeOrderIdentifierChallenge;
@@ -24,6 +25,7 @@ class FinalizeOrderEndpointTest {
         @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
         @Override public de.morihofi.acmeserver.types.runtime.BuildMetadata getBuildMetadata() { return null; }
         @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+            @Override public EventBus getEventBus() { return new EventBus(); }
     }
 
     private static AcmeOrderIdentifierChallenge challengeWithStatus(AcmeOrderIdentifier id, AcmeStatus status) {

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderCertEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderCertEndpointTest.java
@@ -1,4 +1,5 @@
 package de.morihofi.acmeserver.core.api.acme.api.endpoints.order;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
 import de.morihofi.acmeserver.cryptography.keys.KeyPairGenerator;
@@ -44,6 +45,7 @@ class OrderCertEndpointTest {
         @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
         @Override public de.morihofi.acmeserver.types.runtime.BuildMetadata getBuildMetadata() { return null; }
         @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+            @Override public EventBus getEventBus() { return new EventBus(); }
     }
 
     private static CertificateConfig cfg(String cn) {

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpointTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/OrderInfoEndpointTest.java
@@ -1,4 +1,5 @@
 package de.morihofi.acmeserver.core.api.acme.api.endpoints.order;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
@@ -25,6 +26,7 @@ class OrderInfoEndpointTest {
         @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
         @Override public de.morihofi.acmeserver.types.runtime.BuildMetadata getBuildMetadata() { return null; }
         @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+            @Override public EventBus getEventBus() { return new EventBus(); }
     }
 
     @Test

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/challenges/DNSChallengeTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/challenges/DNSChallengeTest.java
@@ -1,4 +1,5 @@
 package de.morihofi.acmeserver.core.api.acme.challenges;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 import de.morihofi.acmeserver.cryptography.acme.AcmeTokenCryptography;
 import de.morihofi.acmeserver.cryptography.pem.PemUtil;
@@ -62,6 +63,7 @@ class DNSChallengeTest {
         @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
         @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
         @Override public INetworkClient getNetworkClient() { return net; }
+            @Override public EventBus getEventBus() { return new EventBus(); }
     }
 
     @Test

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/challenges/HTTPChallengeTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/api/acme/challenges/HTTPChallengeTest.java
@@ -1,4 +1,5 @@
 package de.morihofi.acmeserver.core.api.acme.challenges;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -51,6 +52,7 @@ class HTTPChallengeTest {
         @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
         @Override public BuildMetadata getBuildMetadata() { return meta; }
         @Override public INetworkClient getNetworkClient() { return net; }
+            @Override public EventBus getEventBus() { return new EventBus(); }
     }
 
     private HttpServer server;

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspEndpointGetTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspEndpointGetTest.java
@@ -1,4 +1,5 @@
 package de.morihofi.acmeserver.core.certificate.revokeDistribution;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 import com.google.common.jimfs.Jimfs;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
@@ -21,6 +22,7 @@ import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.runtime.BuildMetadata;
 import de.morihofi.acmeserver.core.database.HibernateUtil;
+import de.morihofi.acmeserver.types.events.EventBus;
 import org.hibernate.Transaction;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.ocsp.CertificateID;
@@ -138,7 +140,8 @@ class OcspEndpointGetTest {
         db.setPassword("");
         cfg.setDatabase(db);
 
-        hu = new HibernateUtil(cfg, true);
+        EventBus bus = new EventBus();
+        hu = new HibernateUtil(cfg, true, bus);
 
         RootCa root = new RootCa();
         root.setCertificateConfig(cfg("root"));
@@ -173,6 +176,7 @@ class OcspEndpointGetTest {
             @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return root; }
             @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
             @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+            @Override public EventBus getEventBus() { return bus; }
         };
 
         endpoint = new OcspEndpointGet(si);

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspHelperTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/OcspHelperTest.java
@@ -1,4 +1,5 @@
 package de.morihofi.acmeserver.core.certificate.revokeDistribution;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 import com.google.common.jimfs.Jimfs;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
@@ -22,6 +23,7 @@ import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.runtime.BuildMetadata;
 import de.morihofi.acmeserver.core.database.HibernateUtil;
+import de.morihofi.acmeserver.types.events.EventBus;
 import org.hibernate.Transaction;
 import org.bouncycastle.cert.ocsp.BasicOCSPResp;
 import org.bouncycastle.cert.ocsp.OCSPResp;
@@ -90,7 +92,8 @@ class OcspHelperTest {
         db.setPassword("");
         cfg.setDatabase(db);
 
-        hu = new HibernateUtil(cfg, true);
+        EventBus bus = new EventBus();
+        hu = new HibernateUtil(cfg, true, bus);
 
         RootCa root = new RootCa();
         root.setCertificateConfig(cfg("root"));
@@ -125,6 +128,7 @@ class OcspHelperTest {
             @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return root; }
             @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
             @Override public de.morihofi.acmeserver.types.intf.network.INetworkClient getNetworkClient() { return null; }
+            @Override public EventBus getEventBus() { return bus; }
         };
     }
 

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/helper/cert/CaInitHelperTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/helper/cert/CaInitHelperTest.java
@@ -6,6 +6,7 @@ import de.morihofi.acmeserver.types.config.Config;
 import de.morihofi.acmeserver.types.config.DatabaseConfig;
 import de.morihofi.acmeserver.types.cryptography.keystore.PKCS12KeyStoreConfig;
 import de.morihofi.acmeserver.types.database.entities.RootCa;
+import de.morihofi.acmeserver.types.events.EventBus;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -33,13 +34,14 @@ class CaInitHelperTest {
         db.setPassword("");
         cfg.setDatabase(db);
 
-        HibernateUtil hu = new HibernateUtil(cfg, true);
+        EventBus bus = new EventBus();
+        HibernateUtil hu = new HibernateUtil(cfg, true, bus);
 
         Path ks = Files.createTempDirectory("ks").resolve("store.p12");
         CryptoStoreManager mgr = new CryptoStoreManager(new PKCS12KeyStoreConfig(ks, "pw".toCharArray()));
 
-        RootCa first = CaInitHelper.initializeCA(hu, mgr);
-        RootCa second = CaInitHelper.initializeCA(hu, mgr);
+        RootCa first = CaInitHelper.initializeCA(hu, mgr, bus);
+        RootCa second = CaInitHelper.initializeCA(hu, mgr, bus);
 
         assertEquals(first.getInternalUuid(), second.getInternalUuid());
         assertTrue(mgr.getKeyStore().containsAlias(first.getInternalUuid()));
@@ -55,12 +57,13 @@ class CaInitHelperTest {
         db.setPassword("");
         cfg.setDatabase(db);
 
-        HibernateUtil hu = new HibernateUtil(cfg, true);
+        EventBus bus = new EventBus();
+        HibernateUtil hu = new HibernateUtil(cfg, true, bus);
 
         Path ks = Files.createTempDirectory("ks").resolve("store2.p12");
         CryptoStoreManager mgr = new CryptoStoreManager(new PKCS12KeyStoreConfig(ks, "pw".toCharArray()));
 
-        RootCa root = CaInitHelper.initializeCA(hu, mgr);
+        RootCa root = CaInitHelper.initializeCA(hu, mgr, bus);
 
         try (var s = hu.getSessionFactory().openSession()) {
             long count = s.createQuery("SELECT count(p) FROM AcmeProvisioner p", Long.class).uniqueResult();

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AbstractEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AbstractEvent.java
@@ -1,0 +1,7 @@
+package de.morihofi.acmeserver.types.events;
+
+/**
+ * Base class for all global events.
+ */
+public abstract class AbstractEvent {
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeAccountCreatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeAccountCreatedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when an ACME account is created.
+ */
+@AllArgsConstructor
+@Getter
+public class AcmeAccountCreatedEvent extends AbstractEvent {
+    private final AcmeAccount account;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeAccountCreatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeAccountCreatedEvent.java
@@ -6,7 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when an ACME account is created.
+ * Event fired after a new ACME account was created and stored in the database.
+ * Subscribers can inspect the {@link AcmeAccount} instance to perform
+ * additional tasks such as audit logging.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeAccountDeactivatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeAccountDeactivatedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when an ACME account is deactivated.
+ */
+@AllArgsConstructor
+@Getter
+public class AcmeAccountDeactivatedEvent extends AbstractEvent {
+    private final AcmeAccount account;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeAccountDeactivatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeAccountDeactivatedEvent.java
@@ -6,7 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when an ACME account is deactivated.
+ * Event emitted after an account has been deactivated via the ACME API.
+ * It contains the updated {@link AcmeAccount} so listeners can react to
+ * the deactivation (e.g. revoke certificates or disable services).
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeCertificateCreatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeCertificateCreatedEvent.java
@@ -1,0 +1,18 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.security.cert.X509Certificate;
+
+/**
+ * Event fired after a certificate for an ACME order was created.
+ */
+@AllArgsConstructor
+@Getter
+public class AcmeCertificateCreatedEvent extends AbstractEvent {
+    private final AcmeOrder order;
+    private final X509Certificate certificate;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeCertificateCreatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeCertificateCreatedEvent.java
@@ -8,7 +8,9 @@ import lombok.Getter;
 import java.security.cert.X509Certificate;
 
 /**
- * Event fired after a certificate for an ACME order was created.
+ * Published once a certificate for an ACME order has been generated and stored.
+ * The corresponding order and the resulting {@link java.security.cert.X509Certificate}
+ * are provided for logging or integration with other systems.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeExceptionEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeExceptionEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.exception.ACMEException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when an ACME related exception occurs.
+ */
+@AllArgsConstructor
+@Getter
+public class AcmeExceptionEvent extends AbstractEvent {
+    private final ACMEException exception;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeExceptionEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeExceptionEvent.java
@@ -6,7 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when an ACME related exception occurs.
+ * Event published whenever an {@link de.morihofi.acmeserver.types.exception.ACMEException}
+ * is thrown while processing a request. This allows listeners to react or log
+ * exceptional conditions centrally.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeNonceRedeemedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeNonceRedeemedEvent.java
@@ -1,0 +1,14 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when an ACME nonce was consumed.
+ */
+@AllArgsConstructor
+@Getter
+public class AcmeNonceRedeemedEvent extends AbstractEvent {
+    private final String nonce;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeNonceRedeemedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeNonceRedeemedEvent.java
@@ -5,7 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when an ACME nonce was consumed.
+ * Event emitted after a nonce has been successfully redeemed and therefore
+ * can no longer be used. Useful for audit or rate limiting subscribers.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AfterChallengeEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AfterChallengeEvent.java
@@ -1,0 +1,17 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.api.acme.challenge.AcmeChallengeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired after a challenge was processed.
+ */
+@AllArgsConstructor
+@Getter
+public class AfterChallengeEvent extends AbstractEvent {
+    private final AcmeChallengeType method;
+    private final String challengeId;
+    private final boolean successful;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AfterChallengeEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AfterChallengeEvent.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired after a challenge was processed.
+ * Fired after the ownership challenge has been processed. Contains the result
+ * indicating whether validation succeeded.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeAcmeApiRequestEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeAcmeApiRequestEvent.java
@@ -5,7 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired before processing an ACME API request.
+ * Event fired before processing an ACME API request. The event provides the
+ * request path and HTTP method so listeners can perform logging or additional
+ * security checks.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeAcmeApiRequestEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeAcmeApiRequestEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired before processing an ACME API request.
+ */
+@AllArgsConstructor
+@Getter
+public class BeforeAcmeApiRequestEvent extends AbstractEvent {
+    private final String path;
+    private final String method;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeAcmeCertificateCreatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeAcmeCertificateCreatedEvent.java
@@ -6,7 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired before a certificate for an ACME order is generated.
+ * Triggered right before the certificate for an ACME order is generated. This
+ * allows subscribers to prepare any external systems that need to be aware of
+ * upcoming certificate creation.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeAcmeCertificateCreatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeAcmeCertificateCreatedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired before a certificate for an ACME order is generated.
+ */
+@AllArgsConstructor
+@Getter
+public class BeforeAcmeCertificateCreatedEvent extends AbstractEvent {
+    private final AcmeOrder order;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeChallengeEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeChallengeEvent.java
@@ -1,0 +1,16 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.api.acme.challenge.AcmeChallengeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired before a challenge is processed.
+ */
+@AllArgsConstructor
+@Getter
+public class BeforeChallengeEvent extends AbstractEvent {
+    private final AcmeChallengeType method;
+    private final String challengeId;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeChallengeEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/BeforeChallengeEvent.java
@@ -6,7 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired before a challenge is processed.
+ * Emitted directly before a domain ownership challenge is validated. It
+ * includes the challenge method and identifier so subscribers can prepare
+ * resources or log the attempt.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/EventBus.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/EventBus.java
@@ -1,4 +1,4 @@
-package de.morihofi.acmeserver.utils.event;
+package de.morihofi.acmeserver.types.events;
 
 import de.morihofi.acmeserver.types.events.AbstractEvent;
 import java.util.List;
@@ -7,17 +7,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * Simple thread-safe event bus implementation for global events. It dispatches
- * events to all listeners registered for a given class. Events are delivered in
- * the order they are published. The bus is used across modules to decouple
- * components.
+ * Simple thread-safe event bus implementation. Instances of this class manage
+ * their own set of listeners and are typically owned by an
+ * {@code IServerInstance}.
  */
-public final class GlobalEventBus {
+public class EventBus {
 
-    private static final Map<Class<?>, List<EventListener<?>>> LISTENERS = new ConcurrentHashMap<>();
-
-    private GlobalEventBus() {
-    }
+    private final Map<Class<?>, List<EventListener<?>>> listeners = new ConcurrentHashMap<>();
 
     /**
      * Registers an {@link EventSubscriber} for all event types returned by its {@link EventSubscriber#canHandle()} method.
@@ -25,7 +21,7 @@ public final class GlobalEventBus {
      * @param subscriber subscriber instance
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public static void register(EventSubscriber subscriber) {
+    public void register(EventSubscriber subscriber) {
         for (Class<? extends AbstractEvent> type : subscriber.canHandle()) {
             subscribe((Class) type, (EventListener) subscriber);
         }
@@ -37,7 +33,7 @@ public final class GlobalEventBus {
      * @param subscriber subscriber instance
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public static void unregister(EventSubscriber subscriber) {
+    public void unregister(EventSubscriber subscriber) {
         for (Class<? extends AbstractEvent> type : subscriber.canHandle()) {
             unsubscribe((Class) type, (EventListener) subscriber);
         }
@@ -50,8 +46,8 @@ public final class GlobalEventBus {
      * @param listener  listener to register
      * @param <T>       type of the event
      */
-    public static <T> void subscribe(Class<T> eventType, EventListener<? super T> listener) {
-        LISTENERS.computeIfAbsent(eventType, k -> new CopyOnWriteArrayList<>()).add(listener);
+    public <T> void subscribe(Class<T> eventType, EventListener<? super T> listener) {
+        listeners.computeIfAbsent(eventType, k -> new CopyOnWriteArrayList<>()).add(listener);
     }
 
     /**
@@ -61,8 +57,8 @@ public final class GlobalEventBus {
      * @param listener  listener to unregister
      * @param <T>       type of the event
      */
-    public static <T> void unsubscribe(Class<T> eventType, EventListener<? super T> listener) {
-        List<EventListener<?>> list = LISTENERS.get(eventType);
+    public <T> void unsubscribe(Class<T> eventType, EventListener<? super T> listener) {
+        List<EventListener<?>> list = listeners.get(eventType);
         if (list != null) {
             list.remove(listener);
         }
@@ -75,8 +71,8 @@ public final class GlobalEventBus {
      * @param <T>   type of the event
      */
     @SuppressWarnings("unchecked")
-    public static <T> void publish(T event) {
-        List<EventListener<?>> list = LISTENERS.get(event.getClass());
+    public <T> void publish(T event) {
+        List<EventListener<?>> list = listeners.get(event.getClass());
         if (list != null) {
             for (EventListener<?> l : list) {
                 ((EventListener<T>) l).onEvent(event);

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/EventBus.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/EventBus.java
@@ -1,6 +1,7 @@
 package de.morihofi.acmeserver.types.events;
 
-import de.morihofi.acmeserver.types.events.AbstractEvent;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,6 +12,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * their own set of listeners and are typically owned by an
  * {@code IServerInstance}.
  */
+@Slf4j
 public class EventBus {
 
     private final Map<Class<?>, List<EventListener<?>>> listeners = new ConcurrentHashMap<>();
@@ -23,6 +25,7 @@ public class EventBus {
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void register(EventSubscriber subscriber) {
         for (Class<? extends AbstractEvent> type : subscriber.canHandle()) {
+            log.debug("Registering subscriber {} for event type {}", subscriber.getClass().getName(), type.getName());
             subscribe((Class) type, (EventListener) subscriber);
         }
     }
@@ -35,6 +38,7 @@ public class EventBus {
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void unregister(EventSubscriber subscriber) {
         for (Class<? extends AbstractEvent> type : subscriber.canHandle()) {
+            log.debug("Unregistering subscriber {} from event type {}", subscriber.getClass().getName(), type.getName());
             unsubscribe((Class) type, (EventListener) subscriber);
         }
     }
@@ -47,6 +51,7 @@ public class EventBus {
      * @param <T>       type of the event
      */
     public <T> void subscribe(Class<T> eventType, EventListener<? super T> listener) {
+        log.debug("Subscribing listener {} to event type {}", listener.getClass().getName(), eventType.getName());
         listeners.computeIfAbsent(eventType, k -> new CopyOnWriteArrayList<>()).add(listener);
     }
 
@@ -58,6 +63,7 @@ public class EventBus {
      * @param <T>       type of the event
      */
     public <T> void unsubscribe(Class<T> eventType, EventListener<? super T> listener) {
+        log.debug("Unsubscribing listener {} from event type {}", listener.getClass().getName(), eventType.getName());
         List<EventListener<?>> list = listeners.get(eventType);
         if (list != null) {
             list.remove(listener);
@@ -73,9 +79,14 @@ public class EventBus {
     @SuppressWarnings("unchecked")
     public <T> void publish(T event) {
         List<EventListener<?>> list = listeners.get(event.getClass());
+        log.debug("Publishing event of type {} to {} listener(s)", event.getClass().getName(), list != null ? list.size() : 0);
         if (list != null) {
             for (EventListener<?> l : list) {
-                ((EventListener<T>) l).onEvent(event);
+                try {
+                    ((EventListener<T>) l).onEvent(event);
+                } catch (Exception e) {
+                    log.error("Error while handling event {} in listener {}", event.getClass().getName(), l.getClass().getName(), e);
+                }
             }
         }
     }

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/EventListener.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/EventListener.java
@@ -1,4 +1,4 @@
-package de.morihofi.acmeserver.utils.event;
+package de.morihofi.acmeserver.types.events;
 
 /**
  * Functional interface for handling events.

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/EventSubscriber.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/EventSubscriber.java
@@ -1,4 +1,4 @@
-package de.morihofi.acmeserver.utils.event;
+package de.morihofi.acmeserver.types.events;
 
 import de.morihofi.acmeserver.types.events.AbstractEvent;
 import java.util.List;

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/NewAcmeOrderEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/NewAcmeOrderEvent.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when a new ACME order is created.
+ * Event fired once a new ACME order has been persisted. The {@link AcmeOrder}
+ * entity can be used by listeners to trigger further processing or notifications.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/NewAcmeOrderEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/NewAcmeOrderEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when a new ACME order is created.
+ */
+@AllArgsConstructor
+@Getter
+public class NewAcmeOrderEvent extends AbstractEvent {
+    private final AcmeOrder order;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerCertificateRenewedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerCertificateRenewedEvent.java
@@ -6,7 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired after a provisioner's intermediate certificate was renewed.
+ * Dispatched after a provisioner's intermediate certificate has been renewed
+ * and stored back in the KeyStore. Listeners may reload cached certificates
+ * or inform administrators that new credentials are in place.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerCertificateRenewedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerCertificateRenewedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired after a provisioner's intermediate certificate was renewed.
+ */
+@AllArgsConstructor
+@Getter
+public class ProvisionerCertificateRenewedEvent extends AbstractEvent {
+    private final AcmeProvisioner provisioner;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerCreatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerCreatedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when a new ACME provisioner is created.
+ */
+@AllArgsConstructor
+@Getter
+public class ProvisionerCreatedEvent extends AbstractEvent {
+    private final AcmeProvisioner provisioner;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerCreatedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerCreatedEvent.java
@@ -6,7 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when a new ACME provisioner is created.
+ * Published whenever a new ACME provisioner is created during initialization or
+ * via management interfaces. Useful for automation that must react to newly
+ * available provisioners.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerDeletedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerDeletedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when an ACME provisioner is removed.
+ */
+@AllArgsConstructor
+@Getter
+public class ProvisionerDeletedEvent extends AbstractEvent {
+    private final AcmeProvisioner provisioner;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerDeletedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ProvisionerDeletedEvent.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when an ACME provisioner is removed.
+ * Fired when an existing ACME provisioner is removed from the system. This
+ * allows cleanup of resources that were tied to that provisioner.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerInitializedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerInitializedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when the server configuration and dependencies are initialized.
+ */
+@AllArgsConstructor
+@Getter
+public class ServerInitializedEvent extends AbstractEvent {
+    private final IServerInstance serverInstance;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerInitializedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerInitializedEvent.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when the server configuration and dependencies are initialized.
+ * Emitted after the server instance has been created and configuration loaded
+ * but before the HTTP server starts accepting requests.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerShutdownEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerShutdownEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired when the server is shutting down.
+ */
+@AllArgsConstructor
+@Getter
+public class ServerShutdownEvent extends AbstractEvent {
+    private final IServerInstance serverInstance;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerShutdownEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerShutdownEvent.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired when the server is shutting down.
+ * Published when the runtime shutdown hook is executed. Use this to cleanly
+ * close resources before the JVM exits.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerStartedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerStartedEvent.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Event fired once the HTTP server is ready to accept requests.
+ * Fired when the web server has started and is ready to handle incoming
+ * connections.
  */
 @AllArgsConstructor
 @Getter

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerStartedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/ServerStartedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Event fired once the HTTP server is ready to accept requests.
+ */
+@AllArgsConstructor
+@Getter
+public class ServerStartedEvent extends AbstractEvent {
+    private final IServerInstance serverInstance;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/intf/IServerInstance.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/intf/IServerInstance.java
@@ -6,6 +6,7 @@ import de.morihofi.acmeserver.types.intf.network.INetworkClient;
 import de.morihofi.acmeserver.types.runtime.BuildMetadata;
 import lombok.NonNull;
 import org.hibernate.Session;
+import de.morihofi.acmeserver.types.events.EventBus;
 
 public interface IServerInstance {
     /**
@@ -73,4 +74,12 @@ public interface IServerInstance {
      */
     @NonNull
     INetworkClient getNetworkClient();
+
+    /**
+     * Access to the event bus associated with this server instance.
+     *
+     * @return event bus for publishing and subscribing to events
+     */
+    @NonNull
+    EventBus getEventBus();
 }

--- a/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/intf/IServerInstanceTest.java
+++ b/acmeserver-types/src/test/java/de/morihofi/acmeserver/types/intf/IServerInstanceTest.java
@@ -4,6 +4,7 @@ import de.morihofi.acmeserver.types.database.entities.RootCa;
 import de.morihofi.acmeserver.types.config.Config;
 import de.morihofi.acmeserver.types.intf.network.INetworkClient;
 import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import de.morihofi.acmeserver.types.events.EventBus;
 import org.hibernate.Session;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,9 @@ class IServerInstanceTest {
 
         @Override
         public INetworkClient getNetworkClient() { return null; }
+
+        @Override
+        public EventBus getEventBus() { return null; }
     }
 
     @Test

--- a/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/EventListener.java
+++ b/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/EventListener.java
@@ -1,0 +1,16 @@
+package de.morihofi.acmeserver.utils.event;
+
+/**
+ * Functional interface for handling events.
+ *
+ * @param <T> type of event data
+ */
+@FunctionalInterface
+public interface EventListener<T> {
+    /**
+     * Invoked when an event is published.
+     *
+     * @param event event data
+     */
+    void onEvent(T event);
+}

--- a/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/EventSubscriber.java
+++ b/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/EventSubscriber.java
@@ -4,7 +4,9 @@ import de.morihofi.acmeserver.types.events.AbstractEvent;
 import java.util.List;
 
 /**
- * Listener capable of handling multiple event types.
+ * Listener capable of handling multiple event types. Implementations return a
+ * list of event classes from {@link #canHandle()} indicating which events they
+ * want to receive.
  */
 public interface EventSubscriber extends EventListener<AbstractEvent> {
     /**

--- a/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/EventSubscriber.java
+++ b/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/EventSubscriber.java
@@ -1,0 +1,16 @@
+package de.morihofi.acmeserver.utils.event;
+
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+import java.util.List;
+
+/**
+ * Listener capable of handling multiple event types.
+ */
+public interface EventSubscriber extends EventListener<AbstractEvent> {
+    /**
+     * Returns the list of event classes this subscriber can handle.
+     *
+     * @return list of event types
+     */
+    List<Class<? extends AbstractEvent>> canHandle();
+}

--- a/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/GlobalEventBus.java
+++ b/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/GlobalEventBus.java
@@ -1,0 +1,83 @@
+package de.morihofi.acmeserver.utils.event;
+
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Simple thread-safe event bus implementation for global events.
+ */
+public final class GlobalEventBus {
+
+    private static final Map<Class<?>, List<EventListener<?>>> LISTENERS = new ConcurrentHashMap<>();
+
+    private GlobalEventBus() {
+    }
+
+    /**
+     * Registers an {@link EventSubscriber} for all event types returned by its {@link EventSubscriber#canHandle()} method.
+     *
+     * @param subscriber subscriber instance
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static void register(EventSubscriber subscriber) {
+        for (Class<? extends AbstractEvent> type : subscriber.canHandle()) {
+            subscribe((Class) type, (EventListener) subscriber);
+        }
+    }
+
+    /**
+     * Unregisters an {@link EventSubscriber} from all events it handles.
+     *
+     * @param subscriber subscriber instance
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static void unregister(EventSubscriber subscriber) {
+        for (Class<? extends AbstractEvent> type : subscriber.canHandle()) {
+            unsubscribe((Class) type, (EventListener) subscriber);
+        }
+    }
+
+    /**
+     * Registers a listener for the given event type.
+     *
+     * @param eventType event class
+     * @param listener  listener to register
+     * @param <T>       type of the event
+     */
+    public static <T> void subscribe(Class<T> eventType, EventListener<? super T> listener) {
+        LISTENERS.computeIfAbsent(eventType, k -> new CopyOnWriteArrayList<>()).add(listener);
+    }
+
+    /**
+     * Unregisters a listener from the given event type.
+     *
+     * @param eventType event class
+     * @param listener  listener to unregister
+     * @param <T>       type of the event
+     */
+    public static <T> void unsubscribe(Class<T> eventType, EventListener<? super T> listener) {
+        List<EventListener<?>> list = LISTENERS.get(eventType);
+        if (list != null) {
+            list.remove(listener);
+        }
+    }
+
+    /**
+     * Publishes an event to all registered listeners.
+     *
+     * @param event event data
+     * @param <T>   type of the event
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> void publish(T event) {
+        List<EventListener<?>> list = LISTENERS.get(event.getClass());
+        if (list != null) {
+            for (EventListener<?> l : list) {
+                ((EventListener<T>) l).onEvent(event);
+            }
+        }
+    }
+}

--- a/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/GlobalEventBus.java
+++ b/acmeserver-utils/src/main/java/de/morihofi/acmeserver/utils/event/GlobalEventBus.java
@@ -7,7 +7,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * Simple thread-safe event bus implementation for global events.
+ * Simple thread-safe event bus implementation for global events. It dispatches
+ * events to all listeners registered for a given class. Events are delivered in
+ * the order they are published. The bus is used across modules to decouple
+ * components.
  */
 public final class GlobalEventBus {
 

--- a/acmeserver-utils/src/test/java/de/morihofi/acmeserver/utils/event/EventBusTest.java
+++ b/acmeserver-utils/src/test/java/de/morihofi/acmeserver/utils/event/EventBusTest.java
@@ -1,6 +1,8 @@
 package de.morihofi.acmeserver.utils.event;
 
 import de.morihofi.acmeserver.types.events.AbstractEvent;
+import de.morihofi.acmeserver.types.events.EventBus;
+import de.morihofi.acmeserver.types.events.EventSubscriber;
 import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
 import de.morihofi.acmeserver.types.events.ServerStartedEvent;
 import de.morihofi.acmeserver.types.events.AcmeAccountCreatedEvent;
@@ -10,7 +12,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class GlobalEventBusTest {
+class EventBusTest {
 
     static class DummySubscriber implements EventSubscriber {
         int count;
@@ -30,25 +32,26 @@ class GlobalEventBusTest {
 
     @Test
     void testRegisterAndPublish() {
+        EventBus bus = new EventBus();
         DummySubscriber sub = new DummySubscriber();
-        GlobalEventBus.register(sub);
+        bus.register(sub);
 
         ServerStartedEvent start = new ServerStartedEvent(null);
-        GlobalEventBus.publish(start);
+        bus.publish(start);
         assertEquals(1, sub.count);
         assertEquals(start, sub.last);
 
         ServerShutdownEvent shut = new ServerShutdownEvent(null);
-        GlobalEventBus.publish(shut);
+        bus.publish(shut);
         assertEquals(2, sub.count);
         assertEquals(shut, sub.last);
 
         // Event not handled should be ignored
-        GlobalEventBus.publish(new AcmeAccountCreatedEvent(null));
+        bus.publish(new AcmeAccountCreatedEvent(null));
         assertEquals(2, sub.count);
 
-        GlobalEventBus.unregister(sub);
-        GlobalEventBus.publish(new ServerStartedEvent(null));
+        bus.unregister(sub);
+        bus.publish(new ServerStartedEvent(null));
         assertEquals(2, sub.count);
     }
 }

--- a/acmeserver-utils/src/test/java/de/morihofi/acmeserver/utils/event/GlobalEventBusTest.java
+++ b/acmeserver-utils/src/test/java/de/morihofi/acmeserver/utils/event/GlobalEventBusTest.java
@@ -1,0 +1,54 @@
+package de.morihofi.acmeserver.utils.event;
+
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
+import de.morihofi.acmeserver.types.events.ServerStartedEvent;
+import de.morihofi.acmeserver.types.events.AcmeAccountCreatedEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GlobalEventBusTest {
+
+    static class DummySubscriber implements EventSubscriber {
+        int count;
+        AbstractEvent last;
+
+        @Override
+        public List<Class<? extends AbstractEvent>> canHandle() {
+            return List.of(ServerStartedEvent.class, ServerShutdownEvent.class);
+        }
+
+        @Override
+        public void onEvent(AbstractEvent event) {
+            count++;
+            last = event;
+        }
+    }
+
+    @Test
+    void testRegisterAndPublish() {
+        DummySubscriber sub = new DummySubscriber();
+        GlobalEventBus.register(sub);
+
+        ServerStartedEvent start = new ServerStartedEvent(null);
+        GlobalEventBus.publish(start);
+        assertEquals(1, sub.count);
+        assertEquals(start, sub.last);
+
+        ServerShutdownEvent shut = new ServerShutdownEvent(null);
+        GlobalEventBus.publish(shut);
+        assertEquals(2, sub.count);
+        assertEquals(shut, sub.last);
+
+        // Event not handled should be ignored
+        GlobalEventBus.publish(new AcmeAccountCreatedEvent(null));
+        assertEquals(2, sub.count);
+
+        GlobalEventBus.unregister(sub);
+        GlobalEventBus.publish(new ServerStartedEvent(null));
+        assertEquals(2, sub.count);
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -508,3 +508,7 @@ further versions. **
   /* ... */
 }
 ```
+
+## Event Flow
+
+Developers can subscribe to lifecycle and ACME events to integrate additional features. The order in which events occur is illustrated in [developer/EventFlow.md](developer/EventFlow.md).

--- a/docs/developer/EventFlow.md
+++ b/docs/developer/EventFlow.md
@@ -1,0 +1,37 @@
+# Event Bus Flow
+
+This document explains how lifecycle and ACME events are emitted by the server. The diagram below shows the typical order in which events are published.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Main
+    participant WebServer
+    participant EventBus
+
+    Main->>EventBus: ServerInitializedEvent
+    Main->>WebServer: startServer
+    WebServer->>EventBus: ServerStartedEvent
+    WebServer->>EventBus: BeforeAcmeApiRequestEvent
+    WebServer->>EventBus: AcmeExceptionEvent (on error)
+    WebServer-->>EventBus: ServerShutdownEvent
+```
+
+For ACME operations an order similar to the following is used:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant API
+    participant EventBus
+
+    API->>EventBus: NewAcmeOrderEvent
+    API->>EventBus: BeforeChallengeEvent
+    API->>EventBus: AfterChallengeEvent
+    API->>EventBus: BeforeAcmeCertificateCreatedEvent
+    API->>EventBus: AcmeCertificateCreatedEvent
+    API->>EventBus: AcmeNonceRedeemedEvent
+```
+
+Each event is dispatched to all registered listeners via `GlobalEventBus`.

--- a/docs/developer/EventFlow.md
+++ b/docs/developer/EventFlow.md
@@ -34,4 +34,4 @@ sequenceDiagram
     API->>EventBus: AcmeNonceRedeemedEvent
 ```
 
-Each event is dispatched to all registered listeners via `GlobalEventBus`.
+Each event is dispatched to all registered listeners via the server instance's `EventBus`.


### PR DESCRIPTION
## Summary
- add `AbstractEvent` base class for all events
- enhance `GlobalEventBus` with registration methods for multi-event subscribers
- introduce `EventSubscriber` interface and unit tests
- publish events for account and order actions
- fire challenge and certificate lifecycle events
- emit events for nonce use and provisioner creation

## Testing
- `mvn -q test` *(tests pass; build output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_684ad6c2b190832280ba713621de6f92