### PR TITLE
feat(cert): rename watcher scheduler

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
@@ -38,7 +38,8 @@ import de.morihofi.acmeserver.types.exception.ACMEException;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEMalformedException;
 import de.morihofi.acmeserver.core.tools.JavalinSecurityHelper;
 import de.morihofi.acmeserver.cryptography.keystore.CryptoStoreManager;
-import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.CertificateRenewManager;
+import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.CertificateRenewScheduler;
+import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.ProvisionerRenewSubscriber;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
 import de.morihofi.acmeserver.core.helper.http.HttpHeaderUtil;
 import de.morihofi.acmeserver.core.tools.network.logging.HTTPAccessLogger;
@@ -67,9 +68,9 @@ public class WebServer {
     private final HTTPAccessLogger httpAccessLogger;
 
     /**
-     * Instance of CertificateRenewManager for managing certificate renewals.
+     * Scheduler for automatically renewing certificates.
      */
-    private final CertificateRenewManager certificateRenewManager;
+    private final CertificateRenewScheduler certificateRenewScheduler;
 
     /**
      * Instance of IServerInstance providing access to server-related configurations and utilities.
@@ -98,7 +99,7 @@ public class WebServer {
     public WebServer(IServerInstance serverInstance) throws IOException {
         this.serverInstance = serverInstance;
         this.httpAccessLogger = new HTTPAccessLogger(serverInstance.getAppConfig(), serverInstance.getEventBus());
-        this.certificateRenewManager = new CertificateRenewManager(serverInstance.getCryptoStoreManager(), serverInstance.getEventBus());
+        this.certificateRenewScheduler = new CertificateRenewScheduler(serverInstance.getCryptoStoreManager(), serverInstance.getEventBus());
     }
 
     /**
@@ -110,7 +111,7 @@ public class WebServer {
         log.info("Starting ACME API WebServer");
 
 
-        JavalinSecurityHelper.initSecureApi(app, serverInstance, certificateRenewManager);
+        JavalinSecurityHelper.initSecureApi(app, serverInstance, certificateRenewScheduler);
 
         app.before(ctx -> {
             ctx.header("Access-Control-Allow-Origin", "*");
@@ -213,8 +214,15 @@ public class WebServer {
 
         log.info("Starting the CRL generation Scheduler");
         CRLScheduler.startScheduler(serverInstance);
+
+        // Register and initialize provisioner certificate watcher
+        ProvisionerRenewSubscriber provisionerWatcher =
+                new ProvisionerRenewSubscriber(serverInstance, certificateRenewScheduler);
+        serverInstance.getEventBus().register(provisionerWatcher);
+        provisionerWatcher.initialize();
+
         log.info("Starting the certificate renew watcher");
-        certificateRenewManager.startScheduler();
+        certificateRenewScheduler.startScheduler();
 
         if (Main.getServerOptions().contains(Main.SERVER_OPTION.USE_ASYNC_CERTIFICATE_ISSUING)) {
             log.info("Starting Certificate Issuer");
@@ -303,7 +311,7 @@ public class WebServer {
 
 
             // Initialize the CertificateRenewWatcher for this provisioner
-            certificateRenewManager.registerNewCertificateRenewWatcher(IntermediateKeyAlias, provisioner,
+            certificateRenewScheduler.registerNewCertificateRenewWatcher(IntermediateKeyAlias, provisioner,
                     (givenProvisioner, x509Certificate, keyPair) -> {
                         return IntermediateCaRenew.renewIntermediateCertificate(keyPair, givenProvisioner,
                                 serverInstance, IntermediateKeyAlias);

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/JavalinSecurityHelper.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/JavalinSecurityHelper.java
@@ -21,7 +21,7 @@ import de.morihofi.acmeserver.types.api.acme.dns.Identifier;
 import de.morihofi.acmeserver.cryptography.keystore.CryptoStoreManager;
 import de.morihofi.acmeserver.cryptography.keys.KeyPairGenerator;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
-import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.CertificateRenewManager;
+import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.CertificateRenewScheduler;
 import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.utils.datetime.DateTools;
@@ -61,7 +61,7 @@ public class JavalinSecurityHelper {
      *                   during automatic certificate renewal.
      */
     public static void initSecureApi(Javalin app, IServerInstance instance,
-                                     CertificateRenewManager certificateRenewManager) throws Exception {
+                                     CertificateRenewScheduler certificateRenewManager) throws Exception {
 
         ICryptoStoreManager cryptoStoreManager = instance.getCryptoStoreManager();
         Config appConfig = instance.getAppConfig();
@@ -102,7 +102,7 @@ public class JavalinSecurityHelper {
 
         {
             String alias = CryptoStoreManager.KEYSTORE_ALIAS_ACMEAPI;
-            CertificateRenewManager.CertificateData certData = generateAcmeApiClientCertificate(instance, appConfig);
+            CertificateRenewScheduler.CertificateData certData = generateAcmeApiClientCertificate(instance, appConfig);
 
             if (certData.keyPair() != null && certData.certificateChain() != null) {
                 log.info("Saving certificate and key for alias {} in keystore", alias);
@@ -164,7 +164,7 @@ public class JavalinSecurityHelper {
      * @throws KeyStoreException         If there is an issue with the keystore.
      * @throws UnrecoverableKeyException If a keystore key cannot be recovered.
      */
-    private static CertificateRenewManager.CertificateData generateAcmeApiClientCertificate(IServerInstance serverInstance,
+    private static CertificateRenewScheduler.CertificateData generateAcmeApiClientCertificate(IServerInstance serverInstance,
                                                                                             Config appConfig) throws CertificateException, IOException, NoSuchAlgorithmException, NoSuchProviderException,
             OperatorCreationException, KeyStoreException, UnrecoverableKeyException {
 
@@ -220,9 +220,9 @@ public class JavalinSecurityHelper {
                     rootCertificate
             };
 
-            return new CertificateRenewManager.CertificateData(chain, acmeAPIKeyPair);
+            return new CertificateRenewScheduler.CertificateData(chain, acmeAPIKeyPair);
         } else {
-            return new CertificateRenewManager.CertificateData(null, null);
+            return new CertificateRenewScheduler.CertificateData(null, null);
         }
     }
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/IntermediateCaRenew.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/IntermediateCaRenew.java
@@ -18,7 +18,7 @@ package de.morihofi.acmeserver.core.tools.certificate.renew;
 
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
-import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.CertificateRenewManager;
+import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.CertificateRenewScheduler;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.operator.OperatorCreationException;
@@ -32,7 +32,7 @@ import java.security.cert.X509Certificate;
 public class IntermediateCaRenew {
 
 
-    public static CertificateRenewManager.CertificateData renewIntermediateCertificate(KeyPair provisionerKeyPair, AcmeProvisioner provisioner,
+    public static CertificateRenewScheduler.CertificateData renewIntermediateCertificate(KeyPair provisionerKeyPair, AcmeProvisioner provisioner,
                                                                                        IServerInstance serverInstance, String intermediateAlias) throws CertificateException, OperatorCreationException,
             IOException, UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException {
 
@@ -58,6 +58,6 @@ public class IntermediateCaRenew {
                 serverInstance.getCryptoStoreManager().getCerificateAuthorityX509Certificate(serverInstance.getRootCa())
         };
 
-        return new CertificateRenewManager.CertificateData(chain, provisionerKeyPair);
+        return new CertificateRenewScheduler.CertificateData(chain, provisionerKeyPair);
     }
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/CertificateRenewScheduler.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/CertificateRenewScheduler.java
@@ -38,10 +38,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Manages the automatic renewal of certificates. Registers certificates to be monitored and renewed if they are about to expire.
+ * Scheduler that periodically checks registered certificates and renews them
+ * when they are close to expiry.
  */
 @Slf4j
-public class CertificateRenewManager {
+public class CertificateRenewScheduler {
     private static final int PERIOD = 6;
     private static final TimeUnit TIME_UNIT = TimeUnit.HOURS;
     private static final int RENEWAL_THRESHOLD_DAYS = 7; // Tage vor Ablauf, an denen das Zertifikat erneuert werden soll
@@ -53,11 +54,11 @@ public class CertificateRenewManager {
     private final Map<String, RenewEntry> renewMap = Collections.synchronizedMap(new HashMap<>());
 
     /**
-     * Constructor for CertificateRenewManager.
+     * Constructs a new scheduler instance.
      *
      * @param cryptoStoreManager The CryptoStoreManager instance used for key and certificate management.
      */
-    public CertificateRenewManager(ICryptoStoreManager cryptoStoreManager, EventBus eventBus) {
+    public CertificateRenewScheduler(ICryptoStoreManager cryptoStoreManager, EventBus eventBus) {
         this.cryptoStoreManager = cryptoStoreManager;
         this.eventBus = eventBus;
     }
@@ -90,6 +91,25 @@ public class CertificateRenewManager {
         }
 
         renewMap.put(alias, new RenewEntry(provisioner, regenerationFunction, triggerAfterRegeneration));
+    }
+
+    /**
+     * Removes a previously registered renew watcher.
+     *
+     * @param alias keystore alias of the watcher to remove
+     */
+    public void unregisterCertificateRenewWatcher(String alias) {
+        renewMap.remove(alias);
+    }
+
+    /**
+     * Checks whether a renew watcher is already registered for the given alias.
+     *
+     * @param alias keystore alias to check
+     * @return {@code true} if a watcher for this alias exists
+     */
+    public boolean isWatcherRegistered(String alias) {
+        return renewMap.containsKey(alias);
     }
 
     /**

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/ProvisionerRenewSubscriber.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/ProvisionerRenewSubscriber.java
@@ -1,0 +1,72 @@
+package de.morihofi.acmeserver.core.tools.certificate.renew.watcher;
+
+import de.morihofi.acmeserver.core.tools.certificate.renew.IntermediateCaRenew;
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+import de.morihofi.acmeserver.types.events.EventSubscriber;
+import de.morihofi.acmeserver.types.events.ProvisionerCreatedEvent;
+import de.morihofi.acmeserver.types.events.ProvisionerDeletedEvent;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.core.tools.certificate.renew.watcher.CertificateRenewScheduler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Event subscriber that keeps the {@link CertificateRenewScheduler} in sync with
+ * the provisioners available on the server. When new provisioners are created
+ * or removed, corresponding renew watchers are registered or deleted.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ProvisionerRenewSubscriber implements EventSubscriber {
+    private final IServerInstance serverInstance;
+    private final CertificateRenewScheduler renewManager;
+
+    /**
+     * Registers watchers for all provisioners currently present in the system.
+     */
+    public void initialize() {
+        AcmeProvisioner[] all = AcmeProvisioner.getAllProvisioners(serverInstance);
+        for (AcmeProvisioner prov : all) {
+            registerWatcher(prov);
+        }
+    }
+
+    private void registerWatcher(AcmeProvisioner prov) {
+        String alias = serverInstance.getCryptoStoreManager()
+                .getKeyStoreAliasForProvisionerIntermediate(prov.getName());
+        if (renewManager.isWatcherRegistered(alias)) {
+            return;
+        }
+        renewManager.registerNewCertificateRenewWatcher(alias, prov,
+                (p, cert, kp) -> IntermediateCaRenew.renewIntermediateCertificate(kp, p,
+                        serverInstance, alias));
+        log.info("Registered renew watcher for provisioner {}", prov.getName());
+    }
+
+    private void unregisterWatcher(AcmeProvisioner prov) {
+        String alias = serverInstance.getCryptoStoreManager()
+                .getKeyStoreAliasForProvisionerIntermediate(prov.getName());
+        if (renewManager.isWatcherRegistered(alias)) {
+            renewManager.unregisterCertificateRenewWatcher(alias);
+            log.info("Unregistered renew watcher for provisioner {}", prov.getName());
+        }
+    }
+
+    @Override
+    public List<Class<? extends AbstractEvent>> canHandle() {
+        return Arrays.asList(ProvisionerCreatedEvent.class, ProvisionerDeletedEvent.class);
+    }
+
+    @Override
+    public void onEvent(AbstractEvent event) {
+        if (event instanceof ProvisionerCreatedEvent created) {
+            registerWatcher(created.getProvisioner());
+        } else if (event instanceof ProvisionerDeletedEvent deleted) {
+            unregisterWatcher(deleted.getProvisioner());
+        }
+    }
+}

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/ProvisionerRenewSubscriberTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/tools/certificate/renew/watcher/ProvisionerRenewSubscriberTest.java
@@ -1,0 +1,85 @@
+package de.morihofi.acmeserver.core.tools.certificate.renew.watcher;
+
+import com.google.common.jimfs.Jimfs;
+import de.morihofi.acmeserver.cryptography.keystore.CryptoStoreManager;
+import de.morihofi.acmeserver.types.config.Config;
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.types.events.EventBus;
+import de.morihofi.acmeserver.types.events.ProvisionerCreatedEvent;
+import de.morihofi.acmeserver.types.events.ProvisionerDeletedEvent;
+import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
+import de.morihofi.acmeserver.types.intf.INonceManager;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.network.INetworkClient;
+import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import de.morihofi.acmeserver.types.cryptography.keystore.PKCS12KeyStoreConfig;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.security.Security;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProvisionerRenewSubscriberTest {
+
+    static class DummyServerInstance implements IServerInstance {
+        private final CryptoStoreManager mgr;
+        private final EventBus bus;
+        DummyServerInstance(CryptoStoreManager mgr, EventBus bus) {
+            this.mgr = mgr; this.bus = bus;
+        }
+        @Override public String getServerURL() { return ""; }
+        @Override public org.hibernate.Session getDatabaseSession() { return null; }
+        @Override public ICryptoStoreManager getCryptoStoreManager() { return mgr; }
+        @Override public Config getAppConfig() { return new Config(); }
+        @Override public INonceManager getNonceManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+        @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
+        @Override public INetworkClient getNetworkClient() { return null; }
+        @Override public EventBus getEventBus() { return bus; }
+    }
+
+    @BeforeAll
+    static void setupProvider() {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    @Test
+    @DisplayName("watcher registers and unregisters on events")
+    void testWatcherLifecycle() throws Exception {
+        FileSystem fs = Jimfs.newFileSystem();
+        Path ksPath = fs.getPath("test.p12");
+        CryptoStoreManager mgr = new CryptoStoreManager(new PKCS12KeyStoreConfig(ksPath, "pw".toCharArray()));
+        EventBus bus = new EventBus();
+        IServerInstance si = new DummyServerInstance(mgr, bus);
+        CertificateRenewScheduler renewManager = new CertificateRenewScheduler(mgr, bus);
+
+        ProvisionerRenewSubscriber watcher = new ProvisionerRenewSubscriber(si, renewManager);
+        bus.register(watcher);
+
+        AcmeProvisioner prov = new AcmeProvisioner();
+        prov.setName("test");
+
+        try (MockedStatic<AcmeProvisioner> mock = Mockito.mockStatic(AcmeProvisioner.class)) {
+            mock.when(() -> AcmeProvisioner.getAllProvisioners(si)).thenReturn(new AcmeProvisioner[]{prov});
+            watcher.initialize();
+        }
+
+        String alias = mgr.getKeyStoreAliasForProvisionerIntermediate("test");
+        assertTrue(renewManager.isWatcherRegistered(alias));
+
+        bus.publish(new ProvisionerDeletedEvent(prov));
+        assertFalse(renewManager.isWatcherRegistered(alias));
+
+        bus.publish(new ProvisionerCreatedEvent(prov));
+        assertTrue(renewManager.isWatcherRegistered(alias));
+    }
+}


### PR DESCRIPTION
## Summary
- rename `CertificateRenewManager` to `CertificateRenewScheduler`
- rename `ProvisionerCertificateWatcher` to `ProvisionerRenewSubscriber`
- update usages throughout core

## Testing
- `sh mvnw -DtrimStackTrace=false test`

------
https://chatgpt.com/codex/tasks/task_e_684b039a01448322bfb45ffae1fb47eb