### PR TITLE
Refactor cert issuing to event bus

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
@@ -28,11 +28,12 @@ import de.morihofi.acmeserver.core.api.acme.api.endpoints.order.FinalizeOrderEnd
 import de.morihofi.acmeserver.core.api.acme.api.endpoints.order.OrderCertEndpoint;
 import de.morihofi.acmeserver.core.api.acme.api.endpoints.order.OrderInfoEndpoint;
 import de.morihofi.acmeserver.core.api.acme.api.endpoints.KeyChangeEndpoint;
-import de.morihofi.acmeserver.core.certificate.queue.CertificateIssuer;
+import de.morihofi.acmeserver.core.certificate.queue.CertificateIssuanceSubscriber;
 import de.morihofi.acmeserver.core.certificate.revokeDistribution.CRLEndpoint;
 import de.morihofi.acmeserver.core.certificate.revokeDistribution.CRLScheduler;
 import de.morihofi.acmeserver.core.certificate.revokeDistribution.OcspEndpointGet;
 import de.morihofi.acmeserver.core.certificate.revokeDistribution.OcspEndpointPost;
+import de.morihofi.acmeserver.core.certificate.revokeDistribution.CrlUpdateSubscriber;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.types.exception.ACMEException;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEMalformedException;
@@ -214,6 +215,7 @@ public class WebServer {
 
         log.info("Starting the CRL generation Scheduler");
         CRLScheduler.startScheduler(serverInstance);
+        serverInstance.getEventBus().register(new CrlUpdateSubscriber(serverInstance));
 
         // Register and initialize provisioner certificate watcher
         ProvisionerRenewSubscriber provisionerWatcher =
@@ -225,8 +227,10 @@ public class WebServer {
         certificateRenewScheduler.startScheduler();
 
         if (Main.getServerOptions().contains(Main.SERVER_OPTION.USE_ASYNC_CERTIFICATE_ISSUING)) {
-            log.info("Starting Certificate Issuer");
-            CertificateIssuer.startThread(serverInstance);
+            log.info("Registering async certificate issuance subscriber");
+            CertificateIssuanceSubscriber sub = new CertificateIssuanceSubscriber(serverInstance);
+            serverInstance.getEventBus().register(sub);
+            sub.initialize();
         }
 
         app.start();

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/RevokeCertEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/RevokeCertEndpoint.java
@@ -27,6 +27,7 @@ import de.morihofi.acmeserver.types.database.entities.AcmeAccount;
 import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.types.database.entities.HttpNonces;
+import de.morihofi.acmeserver.types.events.AcmeCertificateRevokedEvent;
 import de.morihofi.acmeserver.types.exception.exceptions.*;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import io.javalin.http.Context;
@@ -198,6 +199,7 @@ public class RevokeCertEndpoint extends AbstractAcmeEndpoint {
 
         // Revoke it
         AcmeOrder.revokeCertificate(order, reason, getServerInstance());
+        getServerInstance().getEventBus().publish(new AcmeCertificateRevokedEvent(order));
 
         ctx.status(HttpURLConnection.HTTP_OK);
         ctx.header("Replay-Nonce", HttpNonces.createNonce(getServerInstance()));

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/FinalizeOrderEndpoint.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/api/acme/api/endpoints/order/FinalizeOrderEndpoint.java
@@ -26,6 +26,7 @@ import de.morihofi.acmeserver.core.api.acme.api.endpoints.order.objects.Finalize
 import de.morihofi.acmeserver.core.api.acme.api.objects.ACMERequestBody;
 
 import de.morihofi.acmeserver.core.certificate.queue.CertificateIssuer;
+import de.morihofi.acmeserver.types.events.AcmeCertificateIssuanceRequestedEvent;
 import de.morihofi.acmeserver.types.database.entities.*;
 import de.morihofi.acmeserver.types.database.enums.AcmeOrderState;
 import de.morihofi.acmeserver.types.database.enums.AcmeStatus;
@@ -134,11 +135,9 @@ public class FinalizeOrderEndpoint extends AbstractAcmeEndpoint {
                 transaction.commit();
 
                 if (Main.getServerOptions().contains(Main.SERVER_OPTION.USE_ASYNC_CERTIFICATE_ISSUING)) {
-                    // Use async certificate issuing
-
+                    // Use async certificate issuing via event bus
                     log.info("Saved CSR for order {} in database", order.getOrderId());
-
-                    // Set response, that our certificate is processing in separate thread
+                    getServerInstance().getEventBus().publish(new AcmeCertificateIssuanceRequestedEvent(order));
                     response.setStatus(AcmeStatus.PROCESSING.getRfcName());
                 } else {
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuanceSubscriber.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuanceSubscriber.java
@@ -1,0 +1,64 @@
+package de.morihofi.acmeserver.core.certificate.queue;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import de.morihofi.acmeserver.types.database.enums.AcmeOrderState;
+import de.morihofi.acmeserver.types.events.*;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Session;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Subscriber that issues certificates asynchronously when requested via the
+ * {@link AcmeCertificateIssuanceRequestedEvent}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class CertificateIssuanceSubscriber implements EventSubscriber {
+    private final IServerInstance serverInstance;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    /**
+     * Publishes issuance requests for orders which still require a certificate on startup.
+     */
+    public void initialize() {
+        List<AcmeOrder> waiting = AcmeOrder.getAllAcmeOrdersWithState(
+                AcmeOrderState.NEED_A_CERTIFICATE, serverInstance);
+        for (AcmeOrder o : waiting) {
+            serverInstance.getEventBus().publish(new AcmeCertificateIssuanceRequestedEvent(o));
+        }
+    }
+
+    /** Shutdown the executor. */
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    @Override
+    public List<Class<? extends AbstractEvent>> canHandle() {
+        return Arrays.asList(AcmeCertificateIssuanceRequestedEvent.class, ServerShutdownEvent.class);
+    }
+
+    @Override
+    public void onEvent(AbstractEvent event) {
+        if (event instanceof AcmeCertificateIssuanceRequestedEvent req) {
+            executor.submit(() -> issue(req.getOrder()));
+        } else if (event instanceof ServerShutdownEvent) {
+            shutdown();
+        }
+    }
+
+    private void issue(AcmeOrder order) {
+        try (Session session = serverInstance.getDatabaseSession()) {
+            CertificateIssuer.generateCertificateForOrder(order,
+                    serverInstance.getCryptoStoreManager(), session, serverInstance);
+        } catch (Exception ex) {
+            log.error("Error generating certificate for order {}", order.getOrderId(), ex);
+        }
+    }
+}

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuer.java
@@ -29,10 +29,8 @@ import de.morihofi.acmeserver.cryptography.pem.PemUtil;
 import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
 import de.morihofi.acmeserver.utils.network.dns.CAAValidator;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMECaaException;
-import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.BeforeAcmeCertificateCreatedEvent;
 import de.morihofi.acmeserver.types.events.AcmeCertificateCreatedEvent;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.operator.OperatorCreationException;
@@ -49,37 +47,11 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.sql.Timestamp;
-import java.util.List;
 import java.util.Set;
 
 @Slf4j
 public class CertificateIssuer {
 
-    private static Thread certificateQueueIssueThread = null;
-
-    public static synchronized void startThread(@NonNull IServerInstance serverInstance) {
-        log.info("Starting certificate issuing thread...");
-        if (certificateQueueIssueThread == null) {
-            certificateQueueIssueThread = new Thread(new CertificateIssuingTask(serverInstance), "Certificate Issuing Thread");
-            certificateQueueIssueThread.setDaemon(
-                    false); // Continue running until explicitly stopped, so only exit when all certificates are issued
-            certificateQueueIssueThread.start();
-        } else {
-            log.info("Certificate issuing thread is already running.");
-        }
-    }
-
-    public static void shutdown() throws InterruptedException {
-        if (!certificateQueueIssueThread.isInterrupted()) {
-            log.info("Stopping {}", certificateQueueIssueThread.getName());
-            certificateQueueIssueThread.interrupt();
-            while (certificateQueueIssueThread.isAlive()) {
-                log.info("Waiting for {} to exiting", certificateQueueIssueThread.getName());
-                Thread.sleep(1000);
-            }
-            log.info("{} has been stopped", certificateQueueIssueThread.getName());
-        }
-    }
 
     public static void generateCertificateForOrder(@NonNull AcmeOrder order, @NonNull ICryptoStoreManager cryptoStoreManager, @NonNull Session session, @NonNull IServerInstance serverInstance) throws
             IOException, UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException, CertificateException,
@@ -159,39 +131,5 @@ public class CertificateIssuer {
         log.info("Stored certificate successful");
     }
 
-    private record CertificateIssuingTask(@NonNull IServerInstance serverInstance) implements Runnable {
-
-        @SuppressFBWarnings("REC_CATCH_EXCEPTION")
-        @Override
-        public void run() {
-            log.info("Certificate issuing thread started!");
-
-            while (!Thread.currentThread().isInterrupted()) {
-                log.trace("Looking for certificates to be issued in the database");
-
-                List<AcmeOrder> waitingOrders = AcmeOrder.getAllAcmeOrdersWithState(AcmeOrderState.NEED_A_CERTIFICATE, serverInstance);
-
-                if (!waitingOrders.isEmpty()) {
-
-                    try (Session session = serverInstance().getDatabaseSession()) {
-                        AcmeOrder order = waitingOrders.getFirst();
-                        generateCertificateForOrder(order, serverInstance.getCryptoStoreManager(), session, serverInstance);
-                    } catch (Exception ex) {
-                        log.error("Error generating and/or store certificate", ex);
-                    }
-                } else {
-
-                    // Waiting for new CSRs and try in a few seconds again
-                    try {
-
-                        Thread.sleep(20 * 1000); // Sleep 20 seconds
-                    } catch (InterruptedException e) {
-                        log.warn("Thread sleep is interrupted");
-                        Thread.currentThread().interrupt();
-                    }
-                }
-            }
-            log.info("Certificate issuing thread is stopping gracefully.");
-        }
-    }
+    // utility class only
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/CRLScheduler.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/CRLScheduler.java
@@ -31,7 +31,8 @@ public class CRLScheduler {
 
     //FIXME: Add trigger for update crl on provisioner removal/add
 
-    private static final int UPDATE_MINUTES = 720; // 12 hours
+    /** Update interval in minutes used for scheduled CRL generation. */
+    public static final int UPDATE_MINUTES = 720; // 12 hours
 
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/CrlUpdateSubscriber.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/CrlUpdateSubscriber.java
@@ -1,0 +1,32 @@
+package de.morihofi.acmeserver.core.certificate.revokeDistribution;
+
+import de.morihofi.acmeserver.types.events.*;
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Arrays;
+
+/**
+ * Subscriber that regenerates the CRL when a certificate gets revoked.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class CrlUpdateSubscriber implements EventSubscriber {
+    private final IServerInstance serverInstance;
+
+    @Override
+    public List<Class<? extends AbstractEvent>> canHandle() {
+        return Arrays.asList(AcmeCertificateRevokedEvent.class);
+    }
+
+    @Override
+    public void onEvent(AbstractEvent event) {
+        if (event instanceof AcmeCertificateRevokedEvent ev) {
+            AcmeProvisioner prov = ev.getOrder().getAccount().getAcmeProvisioner();
+            CrlStore.updateCachedCRL(CRLScheduler.UPDATE_MINUTES, prov, serverInstance);
+        }
+    }
+}

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuanceSubscriberTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/queue/CertificateIssuanceSubscriberTest.java
@@ -1,0 +1,50 @@
+package de.morihofi.acmeserver.core.certificate.queue;
+
+import de.morihofi.acmeserver.cryptography.keystore.CryptoStoreManager;
+import de.morihofi.acmeserver.types.config.Config;
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import de.morihofi.acmeserver.types.events.AcmeCertificateIssuanceRequestedEvent;
+import de.morihofi.acmeserver.types.events.EventBus;
+import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
+import de.morihofi.acmeserver.types.intf.INonceManager;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.network.INetworkClient;
+import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import org.hibernate.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+
+class CertificateIssuanceSubscriberTest {
+    static class DummyServer implements IServerInstance {
+        private final CryptoStoreManager mgr;
+        private final EventBus bus;
+        private final Session session;
+        DummyServer(CryptoStoreManager mgr, EventBus bus, Session s) {this.mgr=mgr;this.bus=bus;this.session=s;}
+        @Override public String getServerURL(){return "";}@Override public Session getDatabaseSession(){return session;}
+        @Override public ICryptoStoreManager getCryptoStoreManager(){return mgr;}@Override public Config getAppConfig(){return new Config();}
+        @Override public INonceManager getNonceManager(){return null;}@Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa(){return null;}
+        @Override public BuildMetadata getBuildMetadata(){return BuildMetadata.builder().build();}
+        @Override public INetworkClient getNetworkClient(){return null;}@Override public EventBus getEventBus(){return bus;}
+    }
+
+    @Test
+    @DisplayName("subscriber issues certificate on event")
+    void testIssuance() throws Exception {
+        CryptoStoreManager mgr = Mockito.mock(CryptoStoreManager.class);
+        EventBus bus = new EventBus();
+        Session session = Mockito.mock(Session.class);
+        IServerInstance si = new DummyServer(mgr,bus,session);
+        CertificateIssuanceSubscriber sub = new CertificateIssuanceSubscriber(si);
+        bus.register(sub);
+        AcmeOrder order = new AcmeOrder();
+        try (MockedStatic<CertificateIssuer> mock = Mockito.mockStatic(CertificateIssuer.class)) {
+            var m = CertificateIssuanceSubscriber.class.getDeclaredMethod("issue", AcmeOrder.class);
+            m.setAccessible(true);
+            m.invoke(sub, order);
+            mock.verify(() -> CertificateIssuer.generateCertificateForOrder(order, mgr, session, si));
+        }
+    }
+}

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/CrlUpdateSubscriberTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/revokeDistribution/CrlUpdateSubscriberTest.java
@@ -1,0 +1,47 @@
+package de.morihofi.acmeserver.core.certificate.revokeDistribution;
+
+import de.morihofi.acmeserver.cryptography.keystore.CryptoStoreManager;
+import de.morihofi.acmeserver.types.config.Config;
+import de.morihofi.acmeserver.types.database.entities.*;
+import de.morihofi.acmeserver.types.events.AcmeCertificateRevokedEvent;
+import de.morihofi.acmeserver.types.events.EventBus;
+import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
+import de.morihofi.acmeserver.types.intf.INonceManager;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.network.INetworkClient;
+import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import org.hibernate.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+
+class CrlUpdateSubscriberTest {
+    static class DummyServer implements IServerInstance {
+        private final CryptoStoreManager mgr; private final EventBus bus;
+        DummyServer(CryptoStoreManager mgr, EventBus bus){this.mgr=mgr;this.bus=bus;}
+        @Override public String getServerURL(){return "";}@Override public Session getDatabaseSession(){return null;}
+        @Override public ICryptoStoreManager getCryptoStoreManager(){return mgr;}@Override public Config getAppConfig(){return new Config();}
+        @Override public INonceManager getNonceManager(){return null;}@Override public RootCa getRootCa(){return null;}
+        @Override public BuildMetadata getBuildMetadata(){return BuildMetadata.builder().build();}
+        @Override public INetworkClient getNetworkClient(){return null;}@Override public EventBus getEventBus(){return bus;}
+    }
+
+    @Test
+    @DisplayName("subscriber updates CRL on revoke")
+    void testUpdate() {
+        CryptoStoreManager mgr = Mockito.mock(CryptoStoreManager.class);
+        EventBus bus = new EventBus();
+        IServerInstance si = new DummyServer(mgr,bus);
+        CrlUpdateSubscriber sub = new CrlUpdateSubscriber(si);
+        bus.register(sub);
+        AcmeProvisioner prov = new AcmeProvisioner(); prov.setName("p");
+        AcmeAccount acc = new AcmeAccount(); acc.setAcmeProvisioner(prov);
+        AcmeOrder order = new AcmeOrder(); order.setAccount(acc);
+        try (MockedStatic<CrlStore> mock = Mockito.mockStatic(CrlStore.class)) {
+            bus.publish(new AcmeCertificateRevokedEvent(order));
+            mock.verify(() -> CrlStore.updateCachedCRL(CRLScheduler.UPDATE_MINUTES, prov, si));
+        }
+    }
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeCertificateIssuanceRequestedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeCertificateIssuanceRequestedEvent.java
@@ -1,0 +1,16 @@
+package de.morihofi.acmeserver.types.events;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Published when an ACME order requires certificate issuance. This event
+ * allows asynchronous workers to pick up the order and generate the
+ * certificate.
+ */
+@AllArgsConstructor
+@Getter
+public class AcmeCertificateIssuanceRequestedEvent extends AbstractEvent {
+    private final AcmeOrder order;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeCertificateRevokedEvent.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/events/AcmeCertificateRevokedEvent.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.events;
+
+import de.morihofi.acmeserver.types.database.entities.AcmeOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Fired after a certificate has been revoked. Subscribers may refresh CRLs
+ * or perform additional cleanup.
+ */
+@AllArgsConstructor
+@Getter
+public class AcmeCertificateRevokedEvent extends AbstractEvent {
+    private final AcmeOrder order;
+}

--- a/docs/developer/EventFlow.md
+++ b/docs/developer/EventFlow.md
@@ -29,8 +29,10 @@ sequenceDiagram
     API->>EventBus: NewAcmeOrderEvent
     API->>EventBus: BeforeChallengeEvent
     API->>EventBus: AfterChallengeEvent
+    API->>EventBus: AcmeCertificateIssuanceRequestedEvent
     API->>EventBus: BeforeAcmeCertificateCreatedEvent
     API->>EventBus: AcmeCertificateCreatedEvent
+    API->>EventBus: AcmeCertificateRevokedEvent
     API->>EventBus: AcmeNonceRedeemedEvent
 ```
 


### PR DESCRIPTION
## Summary
- issue certificates via `AcmeCertificateIssuanceRequestedEvent`
- react to revocations with `AcmeCertificateRevokedEvent`
- add subscribers for issuance and CRL updates
- update CRL scheduler constant and web server startup
- document new events in developer docs
- add unit tests

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684b42b159108322bebfb5032111bc95