### PR TITLE
Add Certificate Transparency support

### DIFF
--- a/acmeserver-certificatetransparency/pom.xml
+++ b/acmeserver-certificatetransparency/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>de.morihofi.acmeserver</groupId>
+        <artifactId>acmeserver-parent</artifactId>
+        <version>3.0.0</version>
+        <relativePath>../acmeserver-parent/pom.xml</relativePath>
+    </parent>
+    <artifactId>acmeserver-certificatetransparency</artifactId>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.morihofi.acmeserver</groupId>
+            <artifactId>acmeserver-types</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/acmeserver-certificatetransparency/src/main/java/de/morihofi/acmeserver/ct/CertificateTransparencyClient.java
+++ b/acmeserver-certificatetransparency/src/main/java/de/morihofi/acmeserver/ct/CertificateTransparencyClient.java
@@ -1,0 +1,61 @@
+package de.morihofi.acmeserver.ct;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Simple client for submitting certificates to a Certificate Transparency log.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class CertificateTransparencyClient {
+    private static final MediaType JSON = MediaType.parse("application/json");
+    private final OkHttpClient httpClient;
+    private final String logServer;
+
+    /**
+     * Submit a certificate chain to the CT log.
+     *
+     * @param chain           certificate chain starting with the leaf certificate
+     * @param preCertificate  whether to submit using add-pre-chain
+     * @throws IOException if submission fails
+     */
+    public void submitChain(@NonNull List<X509Certificate> chain, boolean preCertificate) throws IOException {
+        String url = logServer + (preCertificate ? "/ct/v1/add-pre-chain" : "/ct/v1/add-chain");
+        JsonArray arr = new JsonArray();
+        for (X509Certificate cert : chain) {
+            try {
+                arr.add(Base64.getEncoder().encodeToString(cert.getEncoded()));
+            } catch (CertificateEncodingException e) {
+                throw new IOException("Failed to encode certificate", e);
+            }
+        }
+        JsonObject obj = new JsonObject();
+        obj.add("chain", arr);
+        String json = new Gson().toJson(obj);
+
+        RequestBody body = RequestBody.create(json, JSON);
+        Request request = new Request.Builder().url(url).post(body).build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("CT log responded with status " + response.code());
+            }
+        }
+    }
+}

--- a/acmeserver-core/pom.xml
+++ b/acmeserver-core/pom.xml
@@ -145,6 +145,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>de.morihofi.acmeserver</groupId>
+            <artifactId>acmeserver-certificatetransparency</artifactId>
+            <version>3.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/WebServer.java
@@ -34,6 +34,7 @@ import de.morihofi.acmeserver.core.certificate.revokeDistribution.CRLScheduler;
 import de.morihofi.acmeserver.core.certificate.revokeDistribution.OcspEndpointGet;
 import de.morihofi.acmeserver.core.certificate.revokeDistribution.OcspEndpointPost;
 import de.morihofi.acmeserver.core.certificate.revokeDistribution.CrlUpdateSubscriber;
+import de.morihofi.acmeserver.core.certificate.transparency.AcmeCertificateTransparencySubscriber;
 import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
 import de.morihofi.acmeserver.types.exception.ACMEException;
 import de.morihofi.acmeserver.types.exception.exceptions.ACMEMalformedException;
@@ -216,6 +217,7 @@ public class WebServer {
         log.info("Starting the CRL generation Scheduler");
         CRLScheduler.startScheduler(serverInstance);
         serverInstance.getEventBus().register(new CrlUpdateSubscriber(serverInstance));
+        serverInstance.getEventBus().register(new AcmeCertificateTransparencySubscriber(serverInstance));
 
         // Register and initialize provisioner certificate watcher
         ProvisionerRenewSubscriber provisionerWatcher =

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/transparency/AcmeCertificateTransparencySubscriber.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/certificate/transparency/AcmeCertificateTransparencySubscriber.java
@@ -1,0 +1,63 @@
+package de.morihofi.acmeserver.core.certificate.transparency;
+
+import de.morihofi.acmeserver.ct.CertificateTransparencyClient;
+import de.morihofi.acmeserver.types.config.CertificateTransparencyConfig;
+import de.morihofi.acmeserver.types.database.entities.AcmeProvisioner;
+import de.morihofi.acmeserver.types.events.*;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Subscriber that submits issued certificates to a Certificate Transparency log.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class AcmeCertificateTransparencySubscriber implements EventSubscriber {
+    private final IServerInstance serverInstance;
+    private final CertificateTransparencyClient ctClient;
+
+    /** Convenience constructor creating a default client. */
+    public AcmeCertificateTransparencySubscriber(@NonNull IServerInstance serverInstance) {
+        this(serverInstance,
+                new CertificateTransparencyClient(
+                        serverInstance.getNetworkClient().getOkHttpClient(),
+                        serverInstance.getAppConfig().getCertificateTransparency().getLogServer()));
+    }
+
+    @Override
+    public List<Class<? extends AbstractEvent>> canHandle() {
+        return Arrays.asList(AcmeCertificateCreatedEvent.class);
+    }
+
+    @Override
+    public void onEvent(AbstractEvent event) {
+        if (event instanceof AcmeCertificateCreatedEvent ev) {
+            CertificateTransparencyConfig cfg = serverInstance.getAppConfig().getCertificateTransparency();
+            if (cfg == null || !cfg.isEnabled()) {
+                return;
+            }
+            try {
+                AcmeProvisioner prov = ev.getOrder().getAccount().getAcmeProvisioner();
+                String alias = serverInstance.getCryptoStoreManager()
+                        .getKeyStoreAliasForProvisionerIntermediate(prov.getName());
+                KeyStore ks = serverInstance.getCryptoStoreManager().getKeyStore();
+                List<X509Certificate> chain = new ArrayList<>();
+                chain.add(ev.getCertificate());
+                for (java.security.cert.Certificate c : ks.getCertificateChain(alias)) {
+                    chain.add((X509Certificate) c);
+                }
+                ctClient.submitChain(chain, cfg.isSubmitPreCertificate());
+            } catch (Exception ex) {
+                log.error("Failed to submit certificate to CT log", ex);
+            }
+        }
+    }
+}

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/transparency/AcmeCertificateTransparencySubscriberTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/certificate/transparency/AcmeCertificateTransparencySubscriberTest.java
@@ -1,0 +1,111 @@
+package de.morihofi.acmeserver.core.certificate.transparency;
+
+import de.morihofi.acmeserver.ct.CertificateTransparencyClient;
+import de.morihofi.acmeserver.cryptography.certificate.X509Generator;
+import de.morihofi.acmeserver.cryptography.keys.KeyPairGenerator;
+import de.morihofi.acmeserver.cryptography.keystore.CryptoStoreManager;
+import de.morihofi.acmeserver.cryptography.pem.PemUtil;
+import de.morihofi.acmeserver.types.api.acme.dns.Identifier;
+import de.morihofi.acmeserver.types.config.CertificateTransparencyConfig;
+import de.morihofi.acmeserver.types.config.Config;
+import de.morihofi.acmeserver.types.database.entities.*;
+import de.morihofi.acmeserver.types.events.AcmeCertificateCreatedEvent;
+import de.morihofi.acmeserver.types.events.EventBus;
+import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
+import de.morihofi.acmeserver.types.intf.INonceManager;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.network.INetworkClient;
+import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import de.morihofi.acmeserver.types.cryptography.keystore.PKCS12KeyStoreConfig;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.List;
+
+class AcmeCertificateTransparencySubscriberTest {
+    static class DummyServer implements IServerInstance {
+        private final CryptoStoreManager mgr; private final EventBus bus; private final Config cfg;
+        DummyServer(CryptoStoreManager mgr, EventBus bus, Config cfg){this.mgr=mgr;this.bus=bus;this.cfg=cfg;}
+        @Override public String getServerURL(){return "";}@Override public org.hibernate.Session getDatabaseSession(){return null;}
+        @Override public ICryptoStoreManager getCryptoStoreManager(){return mgr;}@Override public Config getAppConfig(){return cfg;}
+        @Override public INonceManager getNonceManager(){return null;}@Override public RootCa getRootCa(){return null;}
+        @Override public BuildMetadata getBuildMetadata(){return BuildMetadata.builder().build();}
+        @Override public INetworkClient getNetworkClient(){return null;}@Override public EventBus getEventBus(){return bus;}
+    }
+
+    @BeforeAll
+    static void setupProvider(){Security.addProvider(new BouncyCastleProvider());}
+
+    private static CertificateConfig cfg(String cn){
+        CertificateMetadata meta = new CertificateMetadata(cn, "Org", null, "DE");
+        CertificateExpiration exp = new CertificateExpiration(0,0,1);
+        return new CertificateConfig(meta, exp, null);
+    }
+
+    @Test
+    @DisplayName("subscriber posts chain when enabled")
+    void testSubmission() throws Exception {
+        Path ksPath = Files.createTempDirectory("ks").resolve("store.p12");
+        CryptoStoreManager mgr = new CryptoStoreManager(new PKCS12KeyStoreConfig(ksPath, "pw".toCharArray()));
+        KeyStore ks = mgr.getKeyStore();
+        KeyPair rootKey = KeyPairGenerator.generateRSAKeyPair(512, BouncyCastleProvider.PROVIDER_NAME);
+        X509Certificate rootCert = X509Generator.generate(X509Generator.Request.builder()
+                .type(X509Generator.Type.ROOT_CA)
+                .certificateConfig(cfg("Root"))
+                .ownKeyPair(rootKey)
+                .build());
+        KeyPair interKey = KeyPairGenerator.generateRSAKeyPair(512, BouncyCastleProvider.PROVIDER_NAME);
+        X509Certificate interCert = X509Generator.generate(X509Generator.Request.builder()
+                .type(X509Generator.Type.INTERMEDIATE_CA)
+                .issuerKeyPair(rootKey)
+                .issuerCertificate(rootCert)
+                .ownKeyPair(interKey)
+                .certificateConfig(cfg("Intermediate"))
+                .build());
+        ks.setKeyEntry("intermediateCA_test", interKey.getPrivate(), "".toCharArray(),
+                new java.security.cert.Certificate[]{interCert, rootCert});
+
+        KeyPair serverKey = KeyPairGenerator.generateRSAKeyPair(512, BouncyCastleProvider.PROVIDER_NAME);
+        Identifier id = new Identifier(Identifier.IDENTIFIER_TYPE.DNS, "example.com");
+        Date start = new Date();
+        Date end = new Date(start.getTime()+1000L);
+        X509Certificate serverCert = X509Generator.generate(X509Generator.Request.builder()
+                .type(X509Generator.Type.SERVER)
+                .issuerKeyPair(interKey)
+                .issuerCertificate(interCert)
+                .serverPublicKeyBytes(serverKey.getPublic().getEncoded())
+                .identifier(id)
+                .startDate(start)
+                .endDate(end)
+                .build());
+
+        AcmeProvisioner prov = new AcmeProvisioner(); prov.setName("test");
+        AcmeAccount acc = new AcmeAccount(); acc.setAcmeProvisioner(prov);
+        AcmeOrder order = new AcmeOrder(); order.setAccount(acc);
+        order.setCertificatePem(PemUtil.certificateToPEM(serverCert.getEncoded()));
+
+        EventBus bus = new EventBus();
+        Config cfg = new Config();
+        CertificateTransparencyConfig ctCfg = new CertificateTransparencyConfig();
+        ctCfg.setEnabled(true); ctCfg.setLogServer("http://ct"); ctCfg.setSubmitPreCertificate(false);
+        cfg.setCertificateTransparency(ctCfg);
+        IServerInstance si = new DummyServer(mgr,bus,cfg);
+
+        CertificateTransparencyClient client = Mockito.mock(CertificateTransparencyClient.class);
+        AcmeCertificateTransparencySubscriber sub = new AcmeCertificateTransparencySubscriber(si, client);
+        bus.register(sub);
+
+        bus.publish(new AcmeCertificateCreatedEvent(order, serverCert));
+        Mockito.verify(client).submitChain(Mockito.anyList(), Mockito.eq(false));
+    }
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/config/CertificateTransparencyConfig.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/config/CertificateTransparencyConfig.java
@@ -16,32 +16,19 @@
 
 package de.morihofi.acmeserver.types.config;
 
-import com.google.gson.annotations.SerializedName;
-import de.morihofi.acmeserver.types.config.keyStoreHelpers.KeyStoreParams;
-import de.morihofi.acmeserver.types.config.network.NetworkConfig;
-import de.morihofi.acmeserver.types.config.CertificateTransparencyConfig;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Data;
 
 import java.io.Serializable;
 
 /**
- * Represents a configuration for this ACME Server instance.
+ * Configuration for Certificate Transparency log submission.
  */
 @Data
-@SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
-public class Config implements Serializable {
-    @SerializedName("$schema")
-    private String jsonSchema;
-
-    private ServerConfig server;
-
-    private KeyStoreParams keyStore;
-
-    private DatabaseConfig database;
-
-    private NetworkConfig network = new NetworkConfig();
-
-    private CertificateTransparencyConfig certificateTransparency = new CertificateTransparencyConfig();
-
+public class CertificateTransparencyConfig implements Serializable {
+    /** Enable submission to a CT log. */
+    private boolean enabled = false;
+    /** Base URL of the CT log server. */
+    private String logServer = "http://ctlog:6105";
+    /** Use add-pre-chain endpoint when submitting. */
+    private boolean submitPreCertificate = false;
 }

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -11,3 +11,9 @@ services:
 # Adjust the ports to be the same as in serverdata/settings.json defined
       - "80:80"
       - "443:443"
+
+  tessera:
+    image: ghcr.io/cloudflare/tessera:latest
+    restart: unless-stopped
+    ports:
+      - "6105:6105"

--- a/docs/README.md
+++ b/docs/README.md
@@ -509,6 +509,27 @@ further versions. **
 }
 ```
 
+## Certificate Transparency
+
+ACME Server can optionally submit issued certificates to a Certificate Transparency (CT) log.
+Configure the log connection in the `certificateTransparency` section.
+
+```json
+{
+  /* ... */
+  "certificateTransparency": {
+    "enabled": false,
+    "logServer": "http://tessera:6105",
+    "submitPreCertificate": false
+  }
+  /* ... */
+}
+```
+
+- `enabled`: Enable submission to the CT log.
+- `logServer`: Base URL of the CT log server.
+- `submitPreCertificate`: Use the `/ct/v1/add-pre-chain` endpoint instead of `/ct/v1/add-chain`.
+
 ## Event Flow
 
 Developers can subscribe to lifecycle and ACME events to integrate additional features. The order in which events occur is illustrated in [developer/EventFlow.md](developer/EventFlow.md).

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <module>acmeserver-parent</module>
         <module>acmeserver-types</module>
         <module>acmeserver-cryptography</module>
+        <module>acmeserver-certificatetransparency</module>
     </modules>
 
     <licenses>

--- a/schema.settings.json
+++ b/schema.settings.json
@@ -182,6 +182,15 @@
         "proxy",
         "dnsConfig"
       ]
+    },
+    "certificateTransparency": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "logServer": { "type": "string" },
+        "submitPreCertificate": { "type": "boolean" }
+      },
+      "required": [ "enabled", "logServer", "submitPreCertificate" ]
     }
   },
   "required": [

--- a/settings.sample.json
+++ b/settings.sample.json
@@ -49,5 +49,10 @@
       "dohEnabled": false,
       "dohEndpoint": "https://cloudflare-dns.com/dns-query"
     }
+  },
+  "certificateTransparency": {
+    "enabled": false,
+    "logServer": "http://tessera:6105",
+    "submitPreCertificate": false
   }
 }


### PR DESCRIPTION
## Summary
- configure certificate transparency client
- add CT client module
- submit certs via CT log after issuance
- document new settings and docker-compose service
- provide unit tests for subscriber
- fix docker-compose and sample config after review

## Testing
- `mvn -DskipTests install`
- `mvn -pl acmeserver-core -Dtest=AcmeCertificateTransparencySubscriberTest -Dsurefire.printSummary=true test`


------
https://chatgpt.com/codex/tasks/task_e_684bc62cb968832284d49194b498dd44