### PR TITLE
Add plugin loading system

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -111,7 +111,9 @@ CA.
 
 Place third-party plugin JARs in `serverdata/plugins`. Each plugin should depend on the `acmeserver-types` module and
 implement the `IServerPlugin` interface. Plugins are discovered and initialized automatically on startup allowing them
-to register event subscribers or extend server functionality.
+to register event subscribers or extend server functionality. A JSON configuration file is created for each plugin
+next to its JAR. Properties are scoped by plugin ID and version and can be migrated via `propertyUpdate` when the
+plugin version changes.
 
 ## 🧪 Note for Unit Testing
 

--- a/README.MD
+++ b/README.MD
@@ -107,6 +107,12 @@ Enable debug mode by set environment variable `DEBUG` to `TRUE` or start ACME Se
 Do not use this in production as it disables some security mechanisms (e.g. nonce check) and can lead to misuse of your
 CA.
 
+## 🔌 Plugins
+
+Place third-party plugin JARs in `serverdata/plugins`. Each plugin should depend on the `acmeserver-types` module and
+implement the `IServerPlugin` interface. Plugins are discovered and initialized automatically on startup allowing them
+to register event subscribers or extend server functionality.
+
 ## 🧪 Note for Unit Testing
 
 To be able to run the Unit Test, please make sure, that port `80` (default HTTP Port) is not in use

--- a/README.MD
+++ b/README.MD
@@ -109,11 +109,11 @@ CA.
 
 ## 🔌 Plugins
 
-Place third-party plugin JARs in `serverdata/plugins`. Each plugin should depend on the `acmeserver-types` module and
-implement the `IServerPlugin` interface. Plugins are discovered and initialized automatically on startup allowing them
-to register event subscribers or extend server functionality. A JSON configuration file is created for each plugin
-next to its JAR. Properties are scoped by plugin ID and version and can be migrated via `propertyUpdate` when the
-plugin version changes.
+Place third-party plugins under `serverdata/plugins/<pluginId>` where `<pluginId>` is the unique plugin identifier. The
+directory may contain the plugin JAR and any dependency JARs. Each plugin must depend on the `acmeserver-types` module
+and implement the `IServerPlugin` interface. A `config.json` file is stored in the same directory and contains the
+versioned properties for that plugin. These properties are passed to the plugin on initialization and can be migrated
+using `propertyUpdate` when the plugin version changes.
 
 ## 🧪 Note for Unit Testing
 

--- a/README.MD
+++ b/README.MD
@@ -111,8 +111,9 @@ CA.
 
 Place third-party plugins under `serverdata/plugins/<pluginId>` where `<pluginId>` is the unique plugin identifier. The
 directory may contain the plugin JAR and any dependency JARs. Each plugin must depend on the `acmeserver-types` module
-and implement the `IServerPlugin` interface. A `config.json` file is stored in the same directory and contains the
-versioned properties for that plugin. These properties are passed to the plugin on initialization and can be migrated
+and implement the `IServerPlugin` interface. Each plugin JAR must include a descriptor file located at
+`META-INF/acmeserver-plugin` listing the fully qualified plugin class names to load. A `config.json` file is stored in
+the same directory and contains the versioned properties for that plugin. These properties are passed to the plugin on initialization and can be migrated
 using `propertyUpdate` when the plugin version changes.
 
 ## 🧪 Note for Unit Testing

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/Main.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/Main.java
@@ -39,6 +39,7 @@ import de.morihofi.acmeserver.types.events.EventBus;
 import de.morihofi.acmeserver.types.events.ServerInitializedEvent;
 import de.morihofi.acmeserver.types.events.ServerStartedEvent;
 import de.morihofi.acmeserver.types.events.ServerShutdownEvent;
+import de.morihofi.acmeserver.core.plugin.PluginManager;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -73,6 +74,15 @@ public class Main {
      * Path to the configuration file.
      */
     public static final Path CONFIG_PATH = FILES_DIR.resolve("settings.json");
+
+    /**
+     * Returns the directory used for external plugin JARs.
+     *
+     * @return path to the plugin directory within {@link #FILES_DIR}
+     */
+    public static Path resolveDataPluginsDir() {
+        return FILES_DIR.resolve("plugins");
+    }
 
     /**
      * Set of server options.
@@ -158,6 +168,11 @@ public class Main {
         EventBus eventBus = new EventBus();
         serverInstance = getServerInstance(config, debug, CONFIG_PATH, eventBus);
         eventBus.publish(new ServerInitializedEvent(serverInstance));
+
+        // Load plugins before starting the web server so they can register
+        // their event subscribers.
+        PluginManager pluginManager = new PluginManager(serverInstance);
+        pluginManager.loadPlugins();
 
 
         WebServer ws = new WebServer(serverInstance);

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
@@ -9,6 +9,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.stream.Stream;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
@@ -73,13 +74,13 @@ public class JarPluginLoader {
     }
 
     private static List<Path> getPluginDirs(Path pluginsDir) throws IOException {
-        try (var stream = Files.list(pluginsDir)) {
+        try (Stream<Path> stream = Files.list(pluginsDir)) {
             return stream.filter(Files::isDirectory).toList();
         }
     }
 
     private static List<URL> getJarUrls(Path pluginDir) throws IOException {
-        try (var stream = Files.list(pluginDir)) {
+        try (Stream<Path> stream = Files.list(pluginDir)) {
             return stream.filter(p -> p.toString().endsWith(".jar"))
                     .map(p -> {
                         try {

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
@@ -19,9 +19,12 @@ import java.util.jar.JarInputStream;
 public class JarPluginLoader {
 
     private final Map<String, ClassLoader> registeredClasses;
+    private final Map<ClassLoader, Path> loaderRoots;
 
-    private JarPluginLoader(Map<String, ClassLoader> registeredClasses) {
+    private JarPluginLoader(Map<String, ClassLoader> registeredClasses,
+                            Map<ClassLoader, Path> loaderRoots) {
         this.registeredClasses = registeredClasses;
+        this.loaderRoots = loaderRoots;
     }
 
     /**
@@ -31,26 +34,33 @@ public class JarPluginLoader {
      */
     public static JarPluginLoader getPluginLoader() {
         Map<String, ClassLoader> registered = new HashMap<>();
+        Map<ClassLoader, Path> roots = new HashMap<>();
         log.info("Trying to load external jars ... Please wait");
         try {
             Path pluginsDir = Main.resolveDataPluginsDir();
             validateDirectory(pluginsDir);
 
-            List<Path> jarPaths = getJarPaths(pluginsDir);
-            if (jarPaths.isEmpty()) {
-                log.info("No JAR files found in the plugins directory: {}. Skipping plugin registration", pluginsDir.toAbsolutePath());
-                return new JarPluginLoader(registered);
+            List<Path> pluginDirs = getPluginDirs(pluginsDir);
+            if (pluginDirs.isEmpty()) {
+                log.info("No plugins found in {}", pluginsDir.toAbsolutePath());
+                return new JarPluginLoader(registered, roots);
             }
 
-            for (Path jarPath : jarPaths) {
-                URL jarUrl = jarPath.toUri().toURL();
-                URLClassLoader cl = new URLClassLoader(new URL[]{jarUrl}, JarPluginLoader.class.getClassLoader());
-                loadClassesFromJar(jarUrl, cl, registered);
+            for (Path pluginDir : pluginDirs) {
+                List<URL> jars = getJarUrls(pluginDir);
+                if (jars.isEmpty()) {
+                    continue;
+                }
+                URLClassLoader cl = new URLClassLoader(jars.toArray(new URL[0]), JarPluginLoader.class.getClassLoader());
+                for (URL jarUrl : jars) {
+                    loadClassesFromJar(jarUrl, cl, registered);
+                }
+                roots.put(cl, pluginDir);
             }
         } catch (Exception e) {
             log.warn("Exception occurred while loading jars", e);
         }
-        return new JarPluginLoader(registered);
+        return new JarPluginLoader(registered, roots);
     }
 
     private static void validateDirectory(Path pluginsDir) throws IOException {
@@ -62,10 +72,26 @@ public class JarPluginLoader {
         }
     }
 
-    private static List<Path> getJarPaths(Path pluginsDir) throws IOException {
-        return Files.list(pluginsDir)
-                .filter(p -> p.toString().endsWith(".jar"))
-                .toList();
+    private static List<Path> getPluginDirs(Path pluginsDir) throws IOException {
+        try (var stream = Files.list(pluginsDir)) {
+            return stream.filter(Files::isDirectory).toList();
+        }
+    }
+
+    private static List<URL> getJarUrls(Path pluginDir) throws IOException {
+        try (var stream = Files.list(pluginDir)) {
+            return stream.filter(p -> p.toString().endsWith(".jar"))
+                    .map(p -> {
+                        try {
+                            return p.toUri().toURL();
+                        } catch (Exception e) {
+                            log.warn("Could not convert JAR file path to URL: {}", p, e);
+                            return null;
+                        }
+                    })
+                    .filter(Objects::nonNull)
+                    .toList();
+        }
     }
 
     private static void loadClassesFromJar(URL jarUrl, URLClassLoader classLoader, Map<String, ClassLoader> registered) {
@@ -92,6 +118,12 @@ public class JarPluginLoader {
      */
     public Map<String, ClassLoader> getRegisteredPluginClasses() {
         return Collections.unmodifiableMap(registeredClasses);
+    }
+
+    /** Returns the plugin directory for the given class name. */
+    public Path getPluginRoot(String className) {
+        ClassLoader cl = registeredClasses.get(className);
+        return loaderRoots.get(cl);
     }
 
     /**

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
@@ -1,6 +1,8 @@
 package de.morihofi.acmeserver.core.plugin;
 
 import de.morihofi.acmeserver.core.Main;
+import de.morihofi.acmeserver.types.plugin.PluginInfo;
+import com.google.gson.Gson;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -21,14 +23,19 @@ public class JarPluginLoader {
 
     /** Path inside JAR pointing to the plugin descriptor listing plugin classes. */
     private static final String PLUGIN_DESCRIPTOR = "META-INF/acmeserver-plugin";
+    /** Path inside JAR containing plugin metadata in JSON format. */
+    private static final String PLUGIN_METADATA = "META-INF/acmeserver-plugin.json";
 
     private final Map<String, ClassLoader> registeredClasses;
     private final Map<ClassLoader, Path> loaderRoots;
+    private final Map<String, PluginInfo> pluginInfos;
 
     private JarPluginLoader(Map<String, ClassLoader> registeredClasses,
-                            Map<ClassLoader, Path> loaderRoots) {
+                            Map<ClassLoader, Path> loaderRoots,
+                            Map<String, PluginInfo> pluginInfos) {
         this.registeredClasses = registeredClasses;
         this.loaderRoots = loaderRoots;
+        this.pluginInfos = pluginInfos;
     }
 
     /**
@@ -40,6 +47,7 @@ public class JarPluginLoader {
     public static JarPluginLoader getPluginLoader() {
         Map<String, ClassLoader> registered = new HashMap<>();
         Map<ClassLoader, Path> roots = new HashMap<>();
+        Map<String, PluginInfo> infos = new HashMap<>();
         log.info("Trying to load external jars ... Please wait");
         try {
             Path pluginsDir = Main.resolveDataPluginsDir();
@@ -48,7 +56,7 @@ public class JarPluginLoader {
             List<Path> pluginDirs = getPluginDirs(pluginsDir);
             if (pluginDirs.isEmpty()) {
                 log.info("No plugins found in {}", pluginsDir.toAbsolutePath());
-                return new JarPluginLoader(registered, roots);
+                return new JarPluginLoader(registered, roots, infos);
             }
 
             for (Path pluginDir : pluginDirs) {
@@ -58,14 +66,14 @@ public class JarPluginLoader {
                 }
                 URLClassLoader cl = new URLClassLoader(jars.toArray(new URL[0]), JarPluginLoader.class.getClassLoader());
                 for (URL jarUrl : jars) {
-                    loadClassesFromJar(jarUrl, cl, registered);
+                    loadClassesFromJar(jarUrl, cl, registered, infos);
                 }
                 roots.put(cl, pluginDir);
             }
         } catch (Exception e) {
             log.warn("Exception occurred while loading jars", e);
         }
-        return new JarPluginLoader(registered, roots);
+        return new JarPluginLoader(registered, roots, infos);
     }
 
     private static void validateDirectory(Path pluginsDir) throws IOException {
@@ -100,22 +108,39 @@ public class JarPluginLoader {
     }
 
     private static void loadClassesFromJar(URL jarUrl, URLClassLoader classLoader,
-                                           Map<String, ClassLoader> registered) {
+                                           Map<String, ClassLoader> registered,
+                                           Map<String, PluginInfo> infos) {
         try (JarInputStream jarInputStream = new JarInputStream(jarUrl.openStream())) {
             JarEntry entry;
+            String metadataJson = null;
+            Set<String> classNames = new LinkedHashSet<>();
             while ((entry = jarInputStream.getNextJarEntry()) != null) {
                 if (PLUGIN_DESCRIPTOR.equals(entry.getName())) {
                     try (var reader = new java.io.BufferedReader(new java.io.InputStreamReader(jarInputStream))) {
                         reader.lines()
                                 .map(String::trim)
                                 .filter(l -> !l.isEmpty() && !l.startsWith("#"))
-                                .forEach(className -> {
-                                    registered.put(className, classLoader);
-                                    log.info("Registered class (from {}) : {}", jarUrl.getFile(), className);
-                                });
+                                .forEach(classNames::add);
                     }
-                    break;
+                } else if (PLUGIN_METADATA.equals(entry.getName())) {
+                    metadataJson = new String(jarInputStream.readAllBytes());
                 }
+            }
+            if (metadataJson != null) {
+                try {
+                    Gson gson = new Gson();
+                    PluginInfo info = gson.fromJson(metadataJson, PluginInfo.class);
+                    if (info != null && info.getPluginClass() != null) {
+                        infos.put(info.getPluginClass(), info);
+                        classNames.add(info.getPluginClass());
+                    }
+                } catch (Exception ex) {
+                    log.warn("Failed to parse plugin metadata for {}", jarUrl.getFile(), ex);
+                }
+            }
+            for (String className : classNames) {
+                registered.put(className, classLoader);
+                log.info("Registered class (from {}) : {}", jarUrl.getFile(), className);
             }
         } catch (IOException e) {
             log.warn("Failed to process JAR file: {}", jarUrl, e);
@@ -127,6 +152,11 @@ public class JarPluginLoader {
      */
     public Map<String, ClassLoader> getRegisteredPluginClasses() {
         return Collections.unmodifiableMap(registeredClasses);
+    }
+
+    /** Returns metadata for the given plugin class if available. */
+    public PluginInfo getPluginInfo(String className) {
+        return pluginInfos.get(className);
     }
 
     /** Returns the plugin directory for the given class name. */

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
@@ -18,6 +18,9 @@ import java.util.jar.JarInputStream;
 @Slf4j
 public class JarPluginLoader {
 
+    /** Path inside JAR pointing to the plugin descriptor listing plugin classes. */
+    private static final String PLUGIN_DESCRIPTOR = "META-INF/acmeserver-plugin";
+
     private final Map<String, ClassLoader> registeredClasses;
     private final Map<ClassLoader, Path> loaderRoots;
 
@@ -28,7 +31,8 @@ public class JarPluginLoader {
     }
 
     /**
-     * Scans the plugin directory and loads all classes found in JARs.
+     * Scans the plugin directory and loads plugin classes referenced in
+     * {@value #PLUGIN_DESCRIPTOR} descriptors contained in plugin JARs.
      *
      * @return loader instance containing the registered classes
      */
@@ -94,22 +98,26 @@ public class JarPluginLoader {
         }
     }
 
-    private static void loadClassesFromJar(URL jarUrl, URLClassLoader classLoader, Map<String, ClassLoader> registered) {
+    private static void loadClassesFromJar(URL jarUrl, URLClassLoader classLoader,
+                                           Map<String, ClassLoader> registered) {
         try (JarInputStream jarInputStream = new JarInputStream(jarUrl.openStream())) {
-            processJarEntries(jarInputStream, classLoader, registered, jarUrl);
+            JarEntry entry;
+            while ((entry = jarInputStream.getNextJarEntry()) != null) {
+                if (PLUGIN_DESCRIPTOR.equals(entry.getName())) {
+                    try (var reader = new java.io.BufferedReader(new java.io.InputStreamReader(jarInputStream))) {
+                        reader.lines()
+                                .map(String::trim)
+                                .filter(l -> !l.isEmpty() && !l.startsWith("#"))
+                                .forEach(className -> {
+                                    registered.put(className, classLoader);
+                                    log.info("Registered class (from {}) : {}", jarUrl.getFile(), className);
+                                });
+                    }
+                    break;
+                }
+            }
         } catch (IOException e) {
             log.warn("Failed to process JAR file: {}", jarUrl, e);
-        }
-    }
-
-    private static void processJarEntries(JarInputStream jarInputStream, URLClassLoader classLoader, Map<String, ClassLoader> registered, URL jarUrl) throws IOException {
-        JarEntry entry;
-        while ((entry = jarInputStream.getNextJarEntry()) != null) {
-            if (entry.getName().endsWith(".class")) {
-                String className = entry.getName().replace("/", ".").substring(0, entry.getName().length() - 6);
-                registered.put(className, classLoader);
-                log.info("Registered class (from {}) : {}", jarUrl.getFile(), className);
-            }
         }
     }
 

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
@@ -1,0 +1,111 @@
+package de.morihofi.acmeserver.core.plugin;
+
+import de.morihofi.acmeserver.core.Main;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+/**
+ * Utility for loading external plugin JARs placed in the plugin directory.
+ */
+@Slf4j
+public class JarPluginLoader {
+
+    private final Map<String, ClassLoader> registeredClasses;
+
+    private JarPluginLoader(Map<String, ClassLoader> registeredClasses) {
+        this.registeredClasses = registeredClasses;
+    }
+
+    /**
+     * Scans the plugin directory and loads all classes found in JARs.
+     *
+     * @return loader instance containing the registered classes
+     */
+    public static JarPluginLoader getPluginLoader() {
+        Map<String, ClassLoader> registered = new HashMap<>();
+        log.info("Trying to load external jars ... Please wait");
+        try {
+            Path pluginsDir = Main.resolveDataPluginsDir();
+            validateDirectory(pluginsDir);
+
+            List<Path> jarPaths = getJarPaths(pluginsDir);
+            if (jarPaths.isEmpty()) {
+                log.info("No JAR files found in the plugins directory: {}. Skipping plugin registration", pluginsDir.toAbsolutePath());
+                return new JarPluginLoader(registered);
+            }
+
+            for (Path jarPath : jarPaths) {
+                URL jarUrl = jarPath.toUri().toURL();
+                URLClassLoader cl = new URLClassLoader(new URL[]{jarUrl}, JarPluginLoader.class.getClassLoader());
+                loadClassesFromJar(jarUrl, cl, registered);
+            }
+        } catch (Exception e) {
+            log.warn("Exception occurred while loading jars", e);
+        }
+        return new JarPluginLoader(registered);
+    }
+
+    private static void validateDirectory(Path pluginsDir) throws IOException {
+        if (!Files.exists(pluginsDir)) {
+            Files.createDirectories(pluginsDir);
+        }
+        if (!Files.isDirectory(pluginsDir)) {
+            throw new IllegalStateException("Plugins directory is not a directory: " + pluginsDir.toAbsolutePath());
+        }
+    }
+
+    private static List<Path> getJarPaths(Path pluginsDir) throws IOException {
+        return Files.list(pluginsDir)
+                .filter(p -> p.toString().endsWith(".jar"))
+                .toList();
+    }
+
+    private static void loadClassesFromJar(URL jarUrl, URLClassLoader classLoader, Map<String, ClassLoader> registered) {
+        try (JarInputStream jarInputStream = new JarInputStream(jarUrl.openStream())) {
+            processJarEntries(jarInputStream, classLoader, registered, jarUrl);
+        } catch (IOException e) {
+            log.warn("Failed to process JAR file: {}", jarUrl, e);
+        }
+    }
+
+    private static void processJarEntries(JarInputStream jarInputStream, URLClassLoader classLoader, Map<String, ClassLoader> registered, URL jarUrl) throws IOException {
+        JarEntry entry;
+        while ((entry = jarInputStream.getNextJarEntry()) != null) {
+            if (entry.getName().endsWith(".class")) {
+                String className = entry.getName().replace("/", ".").substring(0, entry.getName().length() - 6);
+                registered.put(className, classLoader);
+                log.info("Registered class (from {}) : {}", jarUrl.getFile(), className);
+            }
+        }
+    }
+
+    /**
+     * Returns the registered plugin classes as an unmodifiable map.
+     */
+    public Map<String, ClassLoader> getRegisteredPluginClasses() {
+        return Collections.unmodifiableMap(registeredClasses);
+    }
+
+    /**
+     * Loads the class with the given fully qualified name using its registered class loader.
+     *
+     * @param fqcn fully qualified class name
+     * @return the loaded class
+     * @throws ClassNotFoundException if the class is not available
+     */
+    public Class<?> getNewInitializedClassInstance(String fqcn) throws ClassNotFoundException {
+        ClassLoader cl = registeredClasses.get(fqcn);
+        if (cl == null) {
+            throw new ClassNotFoundException("Class not found or not registered: " + fqcn);
+        }
+        return Class.forName(fqcn, true, cl);
+    }
+}

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigException.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigException.java
@@ -1,0 +1,12 @@
+package de.morihofi.acmeserver.core.plugin;
+
+/**
+ * Thrown when plugin configuration cannot be loaded or saved.
+ */
+public class PluginConfigException extends Exception {
+
+    /** Creates a new exception with a message and cause. */
+    public PluginConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigStore.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigStore.java
@@ -24,9 +24,14 @@ public class PluginConfigStore {
         this.file = file;
     }
 
-    /** Loads properties from the configured file. */
+    /**
+     * Loads properties from the configured file.
+     *
+     * @return loaded properties or an empty instance if the file is missing
+     * @throws PluginConfigException if the file cannot be read
+     */
     @NonNull
-    public PluginProperties load() {
+    public PluginProperties load() throws PluginConfigException {
         if (!Files.exists(file)) {
             return new PluginProperties();
         }
@@ -34,20 +39,19 @@ public class PluginConfigStore {
             PluginProperties props = gson.fromJson(r, PluginProperties.class);
             return props == null ? new PluginProperties() : props;
         } catch (IOException e) {
-            log.warn("Failed reading plugin properties {}", file, e);
-            return new PluginProperties();
+            throw new PluginConfigException("Failed reading plugin properties " + file, e);
         }
     }
 
     /** Saves the given properties to disk. */
-    public void save(@NonNull PluginProperties props) {
+    public void save(@NonNull PluginProperties props) throws PluginConfigException {
         try {
             Files.createDirectories(file.getParent());
             try (Writer w = Files.newBufferedWriter(file)) {
                 gson.toJson(props, w);
             }
         } catch (IOException e) {
-            log.warn("Failed writing plugin properties {}", file, e);
+            throw new PluginConfigException("Failed writing plugin properties " + file, e);
         }
     }
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigStore.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigStore.java
@@ -1,0 +1,53 @@
+package de.morihofi.acmeserver.core.plugin;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import de.morihofi.acmeserver.types.plugin.PluginProperties;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Simple JSON based storage for plugin configuration properties.
+ */
+@Slf4j
+public class PluginConfigStore {
+    private final Path file;
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    public PluginConfigStore(@NonNull Path file) {
+        this.file = file;
+    }
+
+    /** Loads properties from the configured file. */
+    @NonNull
+    public PluginProperties load() {
+        if (!Files.exists(file)) {
+            return new PluginProperties();
+        }
+        try (Reader r = Files.newBufferedReader(file)) {
+            PluginProperties props = gson.fromJson(r, PluginProperties.class);
+            return props == null ? new PluginProperties() : props;
+        } catch (IOException e) {
+            log.warn("Failed reading plugin properties {}", file, e);
+            return new PluginProperties();
+        }
+    }
+
+    /** Saves the given properties to disk. */
+    public void save(@NonNull PluginProperties props) {
+        try {
+            Files.createDirectories(file.getParent());
+            try (Writer w = Files.newBufferedWriter(file)) {
+                gson.toJson(props, w);
+            }
+        } catch (IOException e) {
+            log.warn("Failed writing plugin properties {}", file, e);
+        }
+    }
+}

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
@@ -1,0 +1,58 @@
+package de.morihofi.acmeserver.core.plugin;
+
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.IServerPlugin;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+/**
+ * Manager responsible for discovering and initializing server plugins.
+ */
+@Slf4j
+public class PluginManager {
+    private final IServerInstance serverInstance;
+    private final JarPluginLoader loader;
+
+    /**
+     * Creates a new plugin manager bound to the given server instance.
+     *
+     * @param serverInstance server instance used for initialization
+     */
+    public PluginManager(IServerInstance serverInstance) {
+        this.serverInstance = serverInstance;
+        this.loader = JarPluginLoader.getPluginLoader();
+    }
+
+    /**
+     * Loads all plugins found in the plugin directory.
+     */
+    public void loadPlugins() {
+        for (Map.Entry<String, ClassLoader> entry : loader.getRegisteredPluginClasses().entrySet()) {
+            String className = entry.getKey();
+            try {
+                Class<?> cls = loader.getNewInitializedClassInstance(className);
+                if (!IServerPlugin.class.isAssignableFrom(cls)) {
+                    continue;
+                }
+                IServerPlugin plugin = (IServerPlugin) cls.getDeclaredConstructor().newInstance();
+                if (!plugin.dependenciesAvailable()) {
+                    log.warn("Skipping plugin {} due to missing dependencies", className);
+                    continue;
+                }
+                plugin.initialize(serverInstance);
+                log.info("Initialized plugin {}", className);
+            } catch (NoClassDefFoundError e) {
+                log.warn("Dependencies missing for plugin {}", className, e);
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                     NoSuchMethodException | ClassNotFoundException e) {
+                log.warn("Failed to load plugin {}", className, e);
+            }
+        }
+    }
+
+    JarPluginLoader getLoader() {
+        return loader;
+    }
+}

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
@@ -8,6 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -17,6 +20,8 @@ import java.util.Map;
 public class PluginManager {
     private final IServerInstance serverInstance;
     private final JarPluginLoader loader;
+    /** List of successfully initialized plugins. */
+    private final List<IServerPlugin> plugins = new ArrayList<>();
 
     /**
      * Creates a new plugin manager bound to the given server instance.
@@ -56,6 +61,7 @@ public class PluginManager {
 
                 plugin.initialize(serverInstance, props.getProperties());
                 store.save(props);
+                plugins.add(plugin);
                 log.info("Initialized plugin {}", className);
             } catch (NoClassDefFoundError e) {
                 log.warn("Dependencies missing for plugin {}", className, e);
@@ -64,6 +70,13 @@ public class PluginManager {
                 log.warn("Failed to load plugin {}", className, e);
             }
         }
+    }
+
+    /**
+     * Returns all successfully initialized plugins.
+     */
+    public List<IServerPlugin> getPlugins() {
+        return Collections.unmodifiableList(plugins);
     }
 
     JarPluginLoader getLoader() {

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
@@ -7,6 +7,7 @@ import de.morihofi.acmeserver.types.plugin.PluginProperties;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -44,10 +45,11 @@ public class PluginManager {
                     continue;
                 }
 
+                Path pluginRoot = loader.getPluginRoot(className);
                 PluginConfigStore store = new PluginConfigStore(
-                        Main.resolveDataPluginsDir().resolve(plugin.getPluginId() + ".json"));
+                        pluginRoot.resolve("config.json"));
                 PluginProperties props = store.load();
-                if (!plugin.getPluginVersion().equals(props.getVersion())) {
+                if (plugin.getPluginVersion() != props.getVersion()) {
                     plugin.propertyUpdate(props.getVersion(), props.getProperties());
                     props.setVersion(plugin.getPluginVersion());
                 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
@@ -4,6 +4,7 @@ import de.morihofi.acmeserver.core.Main;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.intf.IServerPlugin;
 import de.morihofi.acmeserver.types.plugin.PluginProperties;
+import de.morihofi.acmeserver.types.plugin.PluginInfo;
 import de.morihofi.acmeserver.core.plugin.PluginConfigException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -80,6 +81,11 @@ public class PluginManager {
      */
     public List<IServerPlugin> getPlugins() {
         return Collections.unmodifiableList(plugins);
+    }
+
+    /** Returns metadata for a loaded plugin if available. */
+    public PluginInfo getPluginInfo(IServerPlugin plugin) {
+        return loader.getPluginInfo(plugin.getClass().getName());
     }
 
     JarPluginLoader getLoader() {

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
@@ -4,6 +4,7 @@ import de.morihofi.acmeserver.core.Main;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.intf.IServerPlugin;
 import de.morihofi.acmeserver.types.plugin.PluginProperties;
+import de.morihofi.acmeserver.core.plugin.PluginConfigException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.InvocationTargetException;
@@ -62,6 +63,8 @@ public class PluginManager {
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
                      NoSuchMethodException | ClassNotFoundException e) {
                 log.warn("Failed to load plugin {}", className, e);
+            } catch (PluginConfigException e) {
+                log.warn("Failed to access configuration for plugin {}", className, e);
             }
         }
     }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
@@ -1,7 +1,9 @@
 package de.morihofi.acmeserver.core.plugin;
 
+import de.morihofi.acmeserver.core.Main;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.intf.IServerPlugin;
+import de.morihofi.acmeserver.types.plugin.PluginProperties;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.InvocationTargetException;
@@ -41,7 +43,17 @@ public class PluginManager {
                     log.warn("Skipping plugin {} due to missing dependencies", className);
                     continue;
                 }
-                plugin.initialize(serverInstance);
+
+                PluginConfigStore store = new PluginConfigStore(
+                        Main.resolveDataPluginsDir().resolve(plugin.getPluginId() + ".json"));
+                PluginProperties props = store.load();
+                if (!plugin.getPluginVersion().equals(props.getVersion())) {
+                    plugin.propertyUpdate(props.getVersion(), props.getProperties());
+                    props.setVersion(plugin.getPluginVersion());
+                }
+
+                plugin.initialize(serverInstance, props.getProperties());
+                store.save(props);
                 log.info("Initialized plugin {}", className);
             } catch (NoClassDefFoundError e) {
                 log.warn("Dependencies missing for plugin {}", className, e);

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -94,6 +94,9 @@ class PluginManagerTest {
         PluginManager pm = new PluginManager(si);
         pm.loadPlugins();
 
+        assertEquals(1, pm.getPlugins().size());
+        assertEquals("testplugin", pm.getPlugins().get(0).getPluginId());
+
         si.getEventBus().publish(new ServerStartedEvent(si));
 
         Class<?> pluginClass = pm.getLoader().getNewInitializedClassInstance("testplugin.TestPlugin");
@@ -125,6 +128,7 @@ class PluginManagerTest {
         createPluginJar(jar, 2);
         pm = new PluginManager(si);
         pm.loadPlugins();
+        assertEquals(1, pm.getPlugins().size());
         props = store.load();
         assertEquals(2, props.getVersion());
         assertTrue(props.getProperties().containsKey("updated"));

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -79,6 +79,10 @@ class PluginManagerTest {
             jarOut.putNextEntry(new JarEntry("testplugin/TestPlugin.class"));
             jarOut.write(Files.readAllBytes(classFile));
             jarOut.closeEntry();
+
+            jarOut.putNextEntry(new JarEntry("META-INF/acmeserver-plugin"));
+            jarOut.write("testplugin.TestPlugin\n".getBytes());
+            jarOut.closeEntry();
         }
     }
 

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -85,8 +85,8 @@ class PluginManagerTest {
             jarOut.write(Files.readAllBytes(classFile));
             jarOut.closeEntry();
 
-            jarOut.putNextEntry(new JarEntry("META-INF/acmeserver-plugin"));
-            jarOut.write("testplugin.TestPlugin\n".getBytes());
+            jarOut.putNextEntry(new JarEntry("META-INF/acmeserver-plugin.json"));
+            jarOut.write("{\"pluginClass\":\"testplugin.TestPlugin\"}".getBytes());
             jarOut.closeEntry();
         }
     }

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -43,7 +43,7 @@ class PluginManagerTest {
         @Override public EventBus getEventBus() { return bus; }
     }
 
-    private static void createPluginJar(Path jarPath, String version) throws IOException {
+    private static void createPluginJar(Path jarPath, long version) throws IOException {
         Path srcDir = Files.createTempDirectory("plugin-src");
         Path pkgDir = srcDir.resolve("testplugin");
         Files.createDirectories(pkgDir);
@@ -58,9 +58,9 @@ class PluginManagerTest {
                 " public java.util.List<Class<? extends AbstractEvent>> canHandle(){return java.util.List.of(ServerStartedEvent.class);}" +
                 " public void onEvent(AbstractEvent e){if(e instanceof ServerStartedEvent) triggered=true;}" +
                 " public String getPluginId(){return \"testplugin\";}" +
-                " public String getPluginVersion(){return \"" + version + "\";}" +
-                " public void propertyUpdate(String pv, java.util.Map<String,PluginProperty> props){" +
-                "  if(pv==null){props.put(\"fresh\", PluginProperty.ofBoolean(\"fresh\", true));}" +
+                " public long getPluginVersion(){return " + version + ";}" +
+                " public void propertyUpdate(long pv, java.util.Map<String,PluginProperty> props){" +
+                "  if(pv==0){props.put(\"fresh\", PluginProperty.ofBoolean(\"fresh\", true));}" +
                 "  else{props.put(\"updated\", PluginProperty.ofBoolean(\"updated\", true));}}" +
                 "}";
         Files.writeString(javaFile, src, StandardOpenOption.CREATE);
@@ -85,10 +85,10 @@ class PluginManagerTest {
     @Test
     @DisplayName("plugin registers subscriber via event bus")
     void testPluginLoad() throws Exception {
-        Path pluginDir = Main.resolveDataPluginsDir();
+        Path pluginDir = Main.resolveDataPluginsDir().resolve("testplugin");
         Files.createDirectories(pluginDir);
         Path jar = pluginDir.resolve("testplugin.jar");
-        createPluginJar(jar, "1");
+        createPluginJar(jar, 1);
 
         DummyServerInstance si = new DummyServerInstance();
         PluginManager pm = new PluginManager(si);
@@ -106,30 +106,30 @@ class PluginManagerTest {
     @Test
     @DisplayName("plugin properties persisted and updated on version change")
     void testPropertyUpdate() throws Exception {
-        Path pluginDir = Main.resolveDataPluginsDir();
+        Path pluginDir = Main.resolveDataPluginsDir().resolve("testplugin");
         Files.createDirectories(pluginDir);
         Path jar = pluginDir.resolve("testplugin.jar");
 
         // initial load
-        createPluginJar(jar, "1");
+        createPluginJar(jar, 1);
         DummyServerInstance si = new DummyServerInstance();
         PluginManager pm = new PluginManager(si);
         pm.loadPlugins();
 
-        PluginConfigStore store = new PluginConfigStore(pluginDir.resolve("testplugin.json"));
+        PluginConfigStore store = new PluginConfigStore(pluginDir.resolve("config.json"));
         PluginProperties props = store.load();
-        assertEquals("1", props.getVersion());
+        assertEquals(1, props.getVersion());
         assertTrue(props.getProperties().containsKey("fresh"));
 
         // upgrade
-        createPluginJar(jar, "2");
+        createPluginJar(jar, 2);
         pm = new PluginManager(si);
         pm.loadPlugins();
         props = store.load();
-        assertEquals("2", props.getVersion());
+        assertEquals(2, props.getVersion());
         assertTrue(props.getProperties().containsKey("updated"));
 
         Files.deleteIfExists(jar);
-        Files.deleteIfExists(pluginDir.resolve("testplugin.json"));
+        Files.deleteIfExists(pluginDir.resolve("config.json"));
     }
 }

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -11,6 +11,7 @@ import de.morihofi.acmeserver.types.runtime.BuildMetadata;
 import de.morihofi.acmeserver.types.config.Config;
 import de.morihofi.acmeserver.types.plugin.PluginProperties;
 import de.morihofi.acmeserver.core.plugin.PluginConfigStore;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,8 @@ import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
+import java.util.Comparator;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,6 +45,8 @@ class PluginManagerTest {
         @Override public INetworkClient getNetworkClient() { return null; }
         @Override public EventBus getEventBus() { return bus; }
     }
+
+    private Path pluginDir;
 
     private static void createPluginJar(Path jarPath, long version) throws IOException {
         Path srcDir = Files.createTempDirectory("plugin-src");
@@ -82,10 +87,30 @@ class PluginManagerTest {
         }
     }
 
+    private static void deleteDirectory(Path dir) throws IOException {
+        if (dir == null || !Files.exists(dir)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // ignore cleanup errors
+                }
+            });
+        }
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        deleteDirectory(pluginDir);
+    }
+
     @Test
     @DisplayName("plugin registers subscriber via event bus")
     void testPluginLoad() throws Exception {
-        Path pluginDir = Main.resolveDataPluginsDir().resolve("testplugin");
+        pluginDir = Main.resolveDataPluginsDir().resolve("testplugin");
         Files.createDirectories(pluginDir);
         Path jar = pluginDir.resolve("testplugin.jar");
         createPluginJar(jar, 1);
@@ -106,7 +131,7 @@ class PluginManagerTest {
     @Test
     @DisplayName("plugin properties persisted and updated on version change")
     void testPropertyUpdate() throws Exception {
-        Path pluginDir = Main.resolveDataPluginsDir().resolve("testplugin");
+        pluginDir = Main.resolveDataPluginsDir().resolve("testplugin");
         Files.createDirectories(pluginDir);
         Path jar = pluginDir.resolve("testplugin.jar");
 

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -9,6 +9,8 @@ import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.intf.network.INetworkClient;
 import de.morihofi.acmeserver.types.runtime.BuildMetadata;
 import de.morihofi.acmeserver.types.config.Config;
+import de.morihofi.acmeserver.types.plugin.PluginProperties;
+import de.morihofi.acmeserver.core.plugin.PluginConfigStore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +43,7 @@ class PluginManagerTest {
         @Override public EventBus getEventBus() { return bus; }
     }
 
-    private static void createPluginJar(Path jarPath) throws IOException {
+    private static void createPluginJar(Path jarPath, String version) throws IOException {
         Path srcDir = Files.createTempDirectory("plugin-src");
         Path pkgDir = srcDir.resolve("testplugin");
         Files.createDirectories(pkgDir);
@@ -49,11 +51,17 @@ class PluginManagerTest {
         String src = "package testplugin;" +
                 "import de.morihofi.acmeserver.types.intf.*;" +
                 "import de.morihofi.acmeserver.types.events.*;" +
+                "import de.morihofi.acmeserver.types.plugin.*;" +
                 "public class TestPlugin implements IServerPlugin, EventSubscriber {" +
                 " public static boolean triggered=false;" +
-                " public void initialize(IServerInstance si){si.getEventBus().register(this);}" +
+                " public void initialize(IServerInstance si, java.util.Map<String,PluginProperty> props){si.getEventBus().register(this);}" +
                 " public java.util.List<Class<? extends AbstractEvent>> canHandle(){return java.util.List.of(ServerStartedEvent.class);}" +
                 " public void onEvent(AbstractEvent e){if(e instanceof ServerStartedEvent) triggered=true;}" +
+                " public String getPluginId(){return \"testplugin\";}" +
+                " public String getPluginVersion(){return \"" + version + "\";}" +
+                " public void propertyUpdate(String pv, java.util.Map<String,PluginProperty> props){" +
+                "  if(pv==null){props.put(\"fresh\", PluginProperty.ofBoolean(\"fresh\", true));}" +
+                "  else{props.put(\"updated\", PluginProperty.ofBoolean(\"updated\", true));}}" +
                 "}";
         Files.writeString(javaFile, src, StandardOpenOption.CREATE);
 
@@ -80,7 +88,7 @@ class PluginManagerTest {
         Path pluginDir = Main.resolveDataPluginsDir();
         Files.createDirectories(pluginDir);
         Path jar = pluginDir.resolve("testplugin.jar");
-        createPluginJar(jar);
+        createPluginJar(jar, "1");
 
         DummyServerInstance si = new DummyServerInstance();
         PluginManager pm = new PluginManager(si);
@@ -93,5 +101,35 @@ class PluginManagerTest {
         assertTrue(triggered);
 
         Files.deleteIfExists(jar);
+    }
+
+    @Test
+    @DisplayName("plugin properties persisted and updated on version change")
+    void testPropertyUpdate() throws Exception {
+        Path pluginDir = Main.resolveDataPluginsDir();
+        Files.createDirectories(pluginDir);
+        Path jar = pluginDir.resolve("testplugin.jar");
+
+        // initial load
+        createPluginJar(jar, "1");
+        DummyServerInstance si = new DummyServerInstance();
+        PluginManager pm = new PluginManager(si);
+        pm.loadPlugins();
+
+        PluginConfigStore store = new PluginConfigStore(pluginDir.resolve("testplugin.json"));
+        PluginProperties props = store.load();
+        assertEquals("1", props.getVersion());
+        assertTrue(props.getProperties().containsKey("fresh"));
+
+        // upgrade
+        createPluginJar(jar, "2");
+        pm = new PluginManager(si);
+        pm.loadPlugins();
+        props = store.load();
+        assertEquals("2", props.getVersion());
+        assertTrue(props.getProperties().containsKey("updated"));
+
+        Files.deleteIfExists(jar);
+        Files.deleteIfExists(pluginDir.resolve("testplugin.json"));
     }
 }

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -1,0 +1,97 @@
+package de.morihofi.acmeserver.core.plugin;
+
+import de.morihofi.acmeserver.core.Main;
+import de.morihofi.acmeserver.types.events.EventBus;
+import de.morihofi.acmeserver.types.events.ServerStartedEvent;
+import de.morihofi.acmeserver.types.intf.ICryptoStoreManager;
+import de.morihofi.acmeserver.types.intf.INonceManager;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.network.INetworkClient;
+import de.morihofi.acmeserver.types.runtime.BuildMetadata;
+import de.morihofi.acmeserver.types.config.Config;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PluginManagerTest {
+
+    static class DummyServerInstance implements IServerInstance {
+        private final EventBus bus = new EventBus();
+        @Override public String getServerURL() { return ""; }
+        @Override public org.hibernate.Session getDatabaseSession() { return null; }
+        @Override public ICryptoStoreManager getCryptoStoreManager() { return null; }
+        @Override public Config getAppConfig() { return new Config(); }
+        @Override public INonceManager getNonceManager() { return null; }
+        @Override public de.morihofi.acmeserver.types.database.entities.RootCa getRootCa() { return null; }
+        @Override public BuildMetadata getBuildMetadata() { return BuildMetadata.builder().build(); }
+        @Override public INetworkClient getNetworkClient() { return null; }
+        @Override public EventBus getEventBus() { return bus; }
+    }
+
+    private static void createPluginJar(Path jarPath) throws IOException {
+        Path srcDir = Files.createTempDirectory("plugin-src");
+        Path pkgDir = srcDir.resolve("testplugin");
+        Files.createDirectories(pkgDir);
+        Path javaFile = pkgDir.resolve("TestPlugin.java");
+        String src = "package testplugin;" +
+                "import de.morihofi.acmeserver.types.intf.*;" +
+                "import de.morihofi.acmeserver.types.events.*;" +
+                "public class TestPlugin implements IServerPlugin, EventSubscriber {" +
+                " public static boolean triggered=false;" +
+                " public void initialize(IServerInstance si){si.getEventBus().register(this);}" +
+                " public java.util.List<Class<? extends AbstractEvent>> canHandle(){return java.util.List.of(ServerStartedEvent.class);}" +
+                " public void onEvent(AbstractEvent e){if(e instanceof ServerStartedEvent) triggered=true;}" +
+                "}";
+        Files.writeString(javaFile, src, StandardOpenOption.CREATE);
+
+        Path classesDir = Files.createTempDirectory("plugin-classes");
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
+            fm.setLocation(javax.tools.StandardLocation.CLASS_OUTPUT, List.of(classesDir.toFile()));
+            fm.setLocation(javax.tools.StandardLocation.CLASS_PATH,
+                    List.of(new File("../acmeserver-types/target/classes")));
+            compiler.getTask(null, fm, null, null, null, fm.getJavaFileObjects(javaFile.toFile())).call();
+        }
+
+        try (JarOutputStream jarOut = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            Path classFile = classesDir.resolve("testplugin/TestPlugin.class");
+            jarOut.putNextEntry(new JarEntry("testplugin/TestPlugin.class"));
+            jarOut.write(Files.readAllBytes(classFile));
+            jarOut.closeEntry();
+        }
+    }
+
+    @Test
+    @DisplayName("plugin registers subscriber via event bus")
+    void testPluginLoad() throws Exception {
+        Path pluginDir = Main.resolveDataPluginsDir();
+        Files.createDirectories(pluginDir);
+        Path jar = pluginDir.resolve("testplugin.jar");
+        createPluginJar(jar);
+
+        DummyServerInstance si = new DummyServerInstance();
+        PluginManager pm = new PluginManager(si);
+        pm.loadPlugins();
+
+        si.getEventBus().publish(new ServerStartedEvent(si));
+
+        Class<?> pluginClass = pm.getLoader().getNewInitializedClassInstance("testplugin.TestPlugin");
+        boolean triggered = pluginClass.getField("triggered").getBoolean(null);
+        assertTrue(triggered);
+
+        Files.deleteIfExists(jar);
+    }
+}

--- a/acmeserver-plugin-notification/pom.xml
+++ b/acmeserver-plugin-notification/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>de.morihofi.acmeserver</groupId>
+        <artifactId>acmeserver-parent</artifactId>
+        <version>3.0.0</version>
+        <relativePath>../acmeserver-parent/pom.xml</relativePath>
+    </parent>
+    <artifactId>acmeserver-plugin-notification</artifactId>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>de.morihofi.acmeserver</groupId>
+            <artifactId>acmeserver-types</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/acmeserver-plugin-notification/src/main/java/de/morihofi/acmeserver/plugin/notification/NotificationPlugin.java
+++ b/acmeserver-plugin-notification/src/main/java/de/morihofi/acmeserver/plugin/notification/NotificationPlugin.java
@@ -1,0 +1,75 @@
+package de.morihofi.acmeserver.plugin.notification;
+
+import de.morihofi.acmeserver.types.events.AbstractEvent;
+import de.morihofi.acmeserver.types.events.EventSubscriber;
+import de.morihofi.acmeserver.types.events.ServerStartedEvent;
+import de.morihofi.acmeserver.types.intf.IServerInstance;
+import de.morihofi.acmeserver.types.intf.IServerPlugin;
+import de.morihofi.acmeserver.types.plugin.PluginProperty;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple plugin that posts a notification to a configured webhook when the server starts.
+ */
+@Slf4j
+public class NotificationPlugin implements IServerPlugin, EventSubscriber {
+
+    private static final String PROP_URL = "webhookUrl";
+    private OkHttpClient client;
+    private String webhookUrl;
+
+    @Override
+    public void initialize(IServerInstance serverInstance, Map<String, PluginProperty> properties) {
+        client = new OkHttpClient();
+        if (properties.containsKey(PROP_URL)) {
+            webhookUrl = properties.get(PROP_URL).asString();
+        }
+        serverInstance.getEventBus().register(this);
+    }
+
+    @Override
+    public String getPluginId() {
+        return "notification";
+    }
+
+    @Override
+    public long getPluginVersion() {
+        return 1;
+    }
+
+    @Override
+    public List<Class<? extends AbstractEvent>> canHandle() {
+        return List.of(ServerStartedEvent.class);
+    }
+
+    @Override
+    public void onEvent(AbstractEvent event) {
+        if (webhookUrl == null || webhookUrl.isEmpty()) {
+            return;
+        }
+        if (event instanceof ServerStartedEvent) {
+            try {
+                Request req = new Request.Builder()
+                        .url(webhookUrl)
+                        .post(RequestBody.create("ACME Server started", MediaType.parse("text/plain")))
+                        .build();
+                try (Response r = client.newCall(req).execute()) {
+                    if (!r.isSuccessful()) {
+                        log.warn("Webhook returned status {}", r.code());
+                    }
+                }
+            } catch (IOException e) {
+                log.warn("Failed sending webhook", e);
+            }
+        }
+    }
+}

--- a/acmeserver-plugin-notification/src/main/resources/META-INF/acmeserver-plugin.json
+++ b/acmeserver-plugin-notification/src/main/resources/META-INF/acmeserver-plugin.json
@@ -1,0 +1,6 @@
+{
+  "pluginClass": "de.morihofi.acmeserver.plugin.notification.NotificationPlugin",
+  "author": "Moritz Hofmann <info@morihofi.de>",
+  "description": "Posts messages to a WebHook on events. Gets triggered on all events, however it is user-configurable.",
+  "version": "${project.version}"
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/intf/IServerPlugin.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/intf/IServerPlugin.java
@@ -33,15 +33,15 @@ public interface IServerPlugin {
      * @return plugin version
      */
     @NonNull
-    String getPluginVersion();
+    long getPluginVersion();
 
     /**
      * Invoked when the plugin version changed and configuration must be migrated.
      *
-     * @param previousVersion previously stored version or {@code null} if first run
+     * @param previousVersion previously stored version or {@code 0} if first run
      * @param properties      modifiable property map for this plugin
      */
-    default void propertyUpdate(String previousVersion, @NonNull Map<String, PluginProperty> properties) {
+    default void propertyUpdate(long previousVersion, @NonNull Map<String, PluginProperty> properties) {
         // default no-op
     }
 

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/intf/IServerPlugin.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/intf/IServerPlugin.java
@@ -1,6 +1,9 @@
 package de.morihofi.acmeserver.types.intf;
 
+import de.morihofi.acmeserver.types.plugin.PluginProperty;
 import lombok.NonNull;
+
+import java.util.Map;
 
 /**
  * Interface for pluggable extensions that integrate with a running
@@ -13,7 +16,34 @@ public interface IServerPlugin {
      *
      * @param serverInstance server instance for registering listeners and accessing services
      */
-    void initialize(@NonNull IServerInstance serverInstance);
+    void initialize(@NonNull IServerInstance serverInstance,
+                    @NonNull Map<String, PluginProperty> properties);
+
+    /**
+     * Unique identifier of the plugin.
+     *
+     * @return plugin ID
+     */
+    @NonNull
+    String getPluginId();
+
+    /**
+     * Current version of the plugin.
+     *
+     * @return plugin version
+     */
+    @NonNull
+    String getPluginVersion();
+
+    /**
+     * Invoked when the plugin version changed and configuration must be migrated.
+     *
+     * @param previousVersion previously stored version or {@code null} if first run
+     * @param properties      modifiable property map for this plugin
+     */
+    default void propertyUpdate(String previousVersion, @NonNull Map<String, PluginProperty> properties) {
+        // default no-op
+    }
 
     /**
      * Checks whether all optional dependencies required by this plugin are available.

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/intf/IServerPlugin.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/intf/IServerPlugin.java
@@ -1,0 +1,27 @@
+package de.morihofi.acmeserver.types.intf;
+
+import lombok.NonNull;
+
+/**
+ * Interface for pluggable extensions that integrate with a running
+ * {@link IServerInstance}. Implementations are loaded at runtime and may
+ * register {@code EventSubscriber}s or provide additional functionality.
+ */
+public interface IServerPlugin {
+    /**
+     * Initializes the plugin with the given server instance.
+     *
+     * @param serverInstance server instance for registering listeners and accessing services
+     */
+    void initialize(@NonNull IServerInstance serverInstance);
+
+    /**
+     * Checks whether all optional dependencies required by this plugin are available.
+     * If this method returns {@code false}, the plugin will not be loaded.
+     *
+     * @return {@code true} if all dependencies are available
+     */
+    default boolean dependenciesAvailable() {
+        return true;
+    }
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginInfo.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginInfo.java
@@ -1,0 +1,26 @@
+package de.morihofi.acmeserver.types.plugin;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Metadata describing a plugin. Parsed from {@code META-INF/acmeserver-plugin.json} inside the plugin JAR.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PluginInfo {
+    /** Human readable plugin author. */
+    private String author;
+    /** Short plugin description. */
+    private String description;
+    /** Path to an icon resource bundled in the plugin JAR. */
+    private String icon;
+    /** String based plugin version. */
+    private String version;
+    /** Fully qualified class name of the plugin implementation. */
+    private String pluginClass;
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginProperties.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginProperties.java
@@ -16,8 +16,11 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PluginProperties {
-    /** Version of the plugin when properties were last saved. */
-    private String version;
+    /**
+     * Numeric version of the plugin when properties were last saved. Version
+     * {@code 0} indicates that the plugin has not been initialized yet.
+     */
+    private long version;
     /** Map of property key to property definition. */
     @Builder.Default
     private Map<String, PluginProperty> properties = new HashMap<>();

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginProperties.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginProperties.java
@@ -1,0 +1,24 @@
+package de.morihofi.acmeserver.types.plugin;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Holds the configuration of a plugin together with the stored version.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PluginProperties {
+    /** Version of the plugin when properties were last saved. */
+    private String version;
+    /** Map of property key to property definition. */
+    @Builder.Default
+    private Map<String, PluginProperty> properties = new HashMap<>();
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginProperty.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginProperty.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.nio.charset.StandardCharsets;
+import java.math.BigDecimal;
 import java.util.Base64;
 
 /**
@@ -30,12 +31,15 @@ public class PluginProperty {
                 .build();
     }
 
-    /** Creates a numeric property using {@code Double.toString}. */
+    /**
+     * Creates a numeric property. The number is stored as a string using
+     * {@link BigDecimal} to preserve precision.
+     */
     public static PluginProperty ofNumber(String key, Number v) {
         return PluginProperty.builder()
                 .key(key)
                 .type(PluginPropertyType.NUMBER)
-                .value(Double.toString(v.doubleValue()))
+                .value(new BigDecimal(v.toString()).toPlainString())
                 .build();
     }
 
@@ -62,9 +66,13 @@ public class PluginProperty {
         return Boolean.parseBoolean(value);
     }
 
-    /** Returns the property value interpreted as a double. */
-    public double asNumber() {
-        return Double.parseDouble(value);
+    /**
+     * Returns the property value interpreted as a {@link BigDecimal}.
+     *
+     * @return numeric value as {@code BigDecimal}
+     */
+    public BigDecimal asNumber() {
+        return new BigDecimal(value);
     }
 
     /** Returns the property value interpreted as a string. */

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginProperty.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginProperty.java
@@ -1,0 +1,79 @@
+package de.morihofi.acmeserver.types.plugin;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Represents a single configuration property for a plugin.
+ * Values are stored as strings to simplify serialization.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PluginProperty {
+    private String key;
+    private PluginPropertyType type;
+    private String value;
+
+    /** Creates a boolean property. */
+    public static PluginProperty ofBoolean(String key, boolean v) {
+        return PluginProperty.builder()
+                .key(key)
+                .type(PluginPropertyType.BOOLEAN)
+                .value(Boolean.toString(v))
+                .build();
+    }
+
+    /** Creates a numeric property using {@code Double.toString}. */
+    public static PluginProperty ofNumber(String key, Number v) {
+        return PluginProperty.builder()
+                .key(key)
+                .type(PluginPropertyType.NUMBER)
+                .value(Double.toString(v.doubleValue()))
+                .build();
+    }
+
+    /** Creates a string property. */
+    public static PluginProperty ofString(String key, String v) {
+        return PluginProperty.builder()
+                .key(key)
+                .type(PluginPropertyType.STRING)
+                .value(v)
+                .build();
+    }
+
+    /** Creates a binary property encoded as Base64. */
+    public static PluginProperty ofBytes(String key, byte[] v) {
+        return PluginProperty.builder()
+                .key(key)
+                .type(PluginPropertyType.BYTES)
+                .value(Base64.getEncoder().encodeToString(v))
+                .build();
+    }
+
+    /** Returns the property value interpreted as a boolean. */
+    public boolean asBoolean() {
+        return Boolean.parseBoolean(value);
+    }
+
+    /** Returns the property value interpreted as a double. */
+    public double asNumber() {
+        return Double.parseDouble(value);
+    }
+
+    /** Returns the property value interpreted as a string. */
+    public String asString() {
+        return value;
+    }
+
+    /** Returns the property value decoded from Base64. */
+    public byte[] asBytes() {
+        return Base64.getDecoder().decode(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginPropertyType.java
+++ b/acmeserver-types/src/main/java/de/morihofi/acmeserver/types/plugin/PluginPropertyType.java
@@ -1,0 +1,15 @@
+package de.morihofi.acmeserver.types.plugin;
+
+/**
+ * Supported data types for plugin configuration properties.
+ */
+public enum PluginPropertyType {
+    /** Boolean value (true/false). */
+    BOOLEAN,
+    /** Numeric value (integer, double, etc.). */
+    NUMBER,
+    /** UTF-8 string value. */
+    STRING,
+    /** Arbitrary binary data stored as Base64. */
+    BYTES
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <module>acmeserver-parent</module>
         <module>acmeserver-types</module>
         <module>acmeserver-cryptography</module>
+        <module>acmeserver-plugin-notification</module>
     </modules>
 
     <licenses>


### PR DESCRIPTION
## Summary
- add `IServerPlugin` to allow initialization hooks
- expose `resolveDataPluginsDir()` in `Main`
- implement `JarPluginLoader` and `PluginManager`
- load plugins during server startup
- document plugin usage in README
- test plugin loading and event bus registration
- isolate classloaders per plugin

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_684bd3135a3c832293a2737699e3f5e4