### PR TITLE
Handle plugin config errors

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigException.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigException.java
@@ -1,0 +1,12 @@
+package de.morihofi.acmeserver.core.plugin;
+
+/**
+ * Thrown when plugin configuration cannot be loaded or saved.
+ */
+public class PluginConfigException extends Exception {
+
+    /** Creates a new exception with a message and cause. */
+    public PluginConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigStore.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginConfigStore.java
@@ -24,9 +24,14 @@ public class PluginConfigStore {
         this.file = file;
     }
 
-    /** Loads properties from the configured file. */
+    /**
+     * Loads properties from the configured file.
+     *
+     * @return loaded properties or an empty instance if the file is missing
+     * @throws PluginConfigException if the file cannot be read
+     */
     @NonNull
-    public PluginProperties load() {
+    public PluginProperties load() throws PluginConfigException {
         if (!Files.exists(file)) {
             return new PluginProperties();
         }
@@ -34,20 +39,19 @@ public class PluginConfigStore {
             PluginProperties props = gson.fromJson(r, PluginProperties.class);
             return props == null ? new PluginProperties() : props;
         } catch (IOException e) {
-            log.warn("Failed reading plugin properties {}", file, e);
-            return new PluginProperties();
+            throw new PluginConfigException("Failed reading plugin properties " + file, e);
         }
     }
 
     /** Saves the given properties to disk. */
-    public void save(@NonNull PluginProperties props) {
+    public void save(@NonNull PluginProperties props) throws PluginConfigException {
         try {
             Files.createDirectories(file.getParent());
             try (Writer w = Files.newBufferedWriter(file)) {
                 gson.toJson(props, w);
             }
         } catch (IOException e) {
-            log.warn("Failed writing plugin properties {}", file, e);
+            throw new PluginConfigException("Failed writing plugin properties " + file, e);
         }
     }
 }

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
@@ -4,6 +4,7 @@ import de.morihofi.acmeserver.core.Main;
 import de.morihofi.acmeserver.types.intf.IServerInstance;
 import de.morihofi.acmeserver.types.intf.IServerPlugin;
 import de.morihofi.acmeserver.types.plugin.PluginProperties;
+import de.morihofi.acmeserver.core.plugin.PluginConfigException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.InvocationTargetException;
@@ -62,6 +63,8 @@ public class PluginManager {
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
                      NoSuchMethodException | ClassNotFoundException e) {
                 log.warn("Failed to load plugin {}", className, e);
+            } catch (PluginConfigException e) {
+                log.warn("Failed to access configuration for plugin {}", className, e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- introduce `PluginConfigException` for plugin config store
- make `PluginConfigStore` throw when load/save fails
- catch `PluginConfigException` in plugin manager

## Testing
- `mvn -q -am -pl acmeserver-core test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684be713d0708322b1b735587923c1df