### PR TITLE
feat(plugin): use descriptor for server plugins

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -111,8 +111,9 @@ CA.
 
 Place third-party plugins under `serverdata/plugins/<pluginId>` where `<pluginId>` is the unique plugin identifier. The
 directory may contain the plugin JAR and any dependency JARs. Each plugin must depend on the `acmeserver-types` module
-and implement the `IServerPlugin` interface. A `config.json` file is stored in the same directory and contains the
-versioned properties for that plugin. These properties are passed to the plugin on initialization and can be migrated
+and implement the `IServerPlugin` interface. Each plugin JAR must include a descriptor file located at
+`META-INF/acmeserver-plugin` listing the fully qualified plugin class names to load. A `config.json` file is stored in
+the same directory and contains the versioned properties for that plugin. These properties are passed to the plugin on initialization and can be migrated
 using `propertyUpdate` when the plugin version changes.
 
 ## 🧪 Note for Unit Testing

--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/JarPluginLoader.java
@@ -18,6 +18,9 @@ import java.util.jar.JarInputStream;
 @Slf4j
 public class JarPluginLoader {
 
+    /** Path inside JAR pointing to the plugin descriptor listing plugin classes. */
+    private static final String PLUGIN_DESCRIPTOR = "META-INF/acmeserver-plugin";
+
     private final Map<String, ClassLoader> registeredClasses;
     private final Map<ClassLoader, Path> loaderRoots;
 
@@ -28,7 +31,8 @@ public class JarPluginLoader {
     }
 
     /**
-     * Scans the plugin directory and loads all classes found in JARs.
+     * Scans the plugin directory and loads plugin classes referenced in
+     * {@value #PLUGIN_DESCRIPTOR} descriptors contained in plugin JARs.
      *
      * @return loader instance containing the registered classes
      */
@@ -94,22 +98,26 @@ public class JarPluginLoader {
         }
     }
 
-    private static void loadClassesFromJar(URL jarUrl, URLClassLoader classLoader, Map<String, ClassLoader> registered) {
+    private static void loadClassesFromJar(URL jarUrl, URLClassLoader classLoader,
+                                           Map<String, ClassLoader> registered) {
         try (JarInputStream jarInputStream = new JarInputStream(jarUrl.openStream())) {
-            processJarEntries(jarInputStream, classLoader, registered, jarUrl);
+            JarEntry entry;
+            while ((entry = jarInputStream.getNextJarEntry()) != null) {
+                if (PLUGIN_DESCRIPTOR.equals(entry.getName())) {
+                    try (var reader = new java.io.BufferedReader(new java.io.InputStreamReader(jarInputStream))) {
+                        reader.lines()
+                                .map(String::trim)
+                                .filter(l -> !l.isEmpty() && !l.startsWith("#"))
+                                .forEach(className -> {
+                                    registered.put(className, classLoader);
+                                    log.info("Registered class (from {}) : {}", jarUrl.getFile(), className);
+                                });
+                    }
+                    break;
+                }
+            }
         } catch (IOException e) {
             log.warn("Failed to process JAR file: {}", jarUrl, e);
-        }
-    }
-
-    private static void processJarEntries(JarInputStream jarInputStream, URLClassLoader classLoader, Map<String, ClassLoader> registered, URL jarUrl) throws IOException {
-        JarEntry entry;
-        while ((entry = jarInputStream.getNextJarEntry()) != null) {
-            if (entry.getName().endsWith(".class")) {
-                String className = entry.getName().replace("/", ".").substring(0, entry.getName().length() - 6);
-                registered.put(className, classLoader);
-                log.info("Registered class (from {}) : {}", jarUrl.getFile(), className);
-            }
         }
     }
 

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -79,6 +79,10 @@ class PluginManagerTest {
             jarOut.putNextEntry(new JarEntry("testplugin/TestPlugin.class"));
             jarOut.write(Files.readAllBytes(classFile));
             jarOut.closeEntry();
+
+            jarOut.putNextEntry(new JarEntry("META-INF/acmeserver-plugin"));
+            jarOut.write("testplugin.TestPlugin\n".getBytes());
+            jarOut.closeEntry();
         }
     }
 


### PR DESCRIPTION
## Summary
- load plugin classes via `META-INF/acmeserver-plugin`
- document descriptor usage in README
- adjust unit test plugin jar creation

## Testing
- `./mvnw -q test` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_684be78827508322a5a2aa38a2d072af