### PR TITLE
feat(plugin): expose loaded plugins

### DIFF
--- a/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
+++ b/acmeserver-core/src/main/java/de/morihofi/acmeserver/core/plugin/PluginManager.java
@@ -8,6 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -17,6 +20,8 @@ import java.util.Map;
 public class PluginManager {
     private final IServerInstance serverInstance;
     private final JarPluginLoader loader;
+    /** List of successfully initialized plugins. */
+    private final List<IServerPlugin> plugins = new ArrayList<>();
 
     /**
      * Creates a new plugin manager bound to the given server instance.
@@ -56,6 +61,7 @@ public class PluginManager {
 
                 plugin.initialize(serverInstance, props.getProperties());
                 store.save(props);
+                plugins.add(plugin);
                 log.info("Initialized plugin {}", className);
             } catch (NoClassDefFoundError e) {
                 log.warn("Dependencies missing for plugin {}", className, e);
@@ -64,6 +70,13 @@ public class PluginManager {
                 log.warn("Failed to load plugin {}", className, e);
             }
         }
+    }
+
+    /**
+     * Returns all successfully initialized plugins.
+     */
+    public List<IServerPlugin> getPlugins() {
+        return Collections.unmodifiableList(plugins);
     }
 
     JarPluginLoader getLoader() {

--- a/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
+++ b/acmeserver-core/src/test/java/de/morihofi/acmeserver/core/plugin/PluginManagerTest.java
@@ -94,6 +94,9 @@ class PluginManagerTest {
         PluginManager pm = new PluginManager(si);
         pm.loadPlugins();
 
+        assertEquals(1, pm.getPlugins().size());
+        assertEquals("testplugin", pm.getPlugins().get(0).getPluginId());
+
         si.getEventBus().publish(new ServerStartedEvent(si));
 
         Class<?> pluginClass = pm.getLoader().getNewInitializedClassInstance("testplugin.TestPlugin");
@@ -125,6 +128,7 @@ class PluginManagerTest {
         createPluginJar(jar, 2);
         pm = new PluginManager(si);
         pm.loadPlugins();
+        assertEquals(1, pm.getPlugins().size());
         props = store.load();
         assertEquals(2, props.getVersion());
         assertTrue(props.getProperties().containsKey("updated"));


### PR DESCRIPTION
## Summary
- keep track of successfully initialized plugins
- provide getter for loaded plugins
- verify plugin list in PluginManager tests

## Testing
- `mvn -q -DskipITs=true test` *(fails: errors during Maven execution)*

------
https://chatgpt.com/codex/tasks/task_e_684be7c5e6c48322ba1aa2ed62976cdc